### PR TITLE
Fix labels being sent as objects to the API endpoint on PR/issue creation

### DIFF
--- a/lib/geet/github/abstract_issue.rb
+++ b/lib/geet/github/abstract_issue.rb
@@ -49,6 +49,8 @@ module Geet
         @api_interface.send_request(api_path, data: request_data)
       end
 
+      # labels: array of strings.
+      #
       def add_labels(labels)
         api_path = "issues/#{@number}/labels"
         request_data = labels

--- a/lib/geet/services/create_issue.rb
+++ b/lib/geet/services/create_issue.rb
@@ -96,7 +96,7 @@ module Geet
         output.puts "Adding labels #{labels_list}..."
 
         Thread.new do
-          issue.add_labels(selected_labels)
+          issue.add_labels(selected_labels.map(&:name))
         end
       end
 

--- a/lib/geet/services/create_pr.rb
+++ b/lib/geet/services/create_pr.rb
@@ -100,7 +100,7 @@ module Geet
         output.puts "Adding labels #{labels_list}..."
 
         Thread.new do
-          pr.add_labels(selected_labels)
+          pr.add_labels(selected_labels.map(&:name))
         end
       end
 


### PR DESCRIPTION
This was not caught due to the VCR gem not testing the requests.