### PR TITLE
Merge Github::Issue.list logic into Github::AbstractIssue.list

### DIFF
--- a/lib/geet/github/abstract_issue.rb
+++ b/lib/geet/github/abstract_issue.rb
@@ -22,21 +22,25 @@ module Geet
 
       # See https://developer.github.com/v3/issues/#list-issues-for-a-repository
       #
-      def self.list(api_interface, milestone: nil)
+      def self.list(api_interface, only_issues: false, milestone: nil)
         api_path = 'issues'
         request_params = { milestone: milestone } if milestone
 
         response = api_interface.send_request(api_path, params: request_params, multipage: true)
 
-        response.map do |issue_data|
+        abstract_issues_list = response.map do |issue_data|
           number = issue_data.fetch('number')
           title = issue_data.fetch('title')
           link = issue_data.fetch('html_url')
 
           klazz = issue_data.key?('pull_request') ? PR : Issue
 
-          klazz.new(number, api_interface, title, link)
+          if !only_issues || klazz == Issue
+            klazz.new(number, api_interface, title, link)
+          end
         end
+
+        abstract_issues_list.compact
       end
 
       # params:

--- a/lib/geet/github/issue.rb
+++ b/lib/geet/github/issue.rb
@@ -20,19 +20,7 @@ module Geet
       # See https://developer.github.com/v3/issues/#list-issues-for-a-repository
       #
       def self.list(api_interface)
-        api_path = 'issues'
-
-        response = api_interface.send_request(api_path, multipage: true)
-
-        response.each_with_object([]) do |issue_data, result|
-          if !issue_data.key?('pull_request')
-            number = issue_data.fetch('number')
-            title = issue_data.fetch('title')
-            link = issue_data.fetch('html_url')
-
-            result << new(number, api_interface, title, link)
-          end
-        end
+        super(api_interface, only_issues: true)
       end
     end
   end


### PR DESCRIPTION
The immediate objective is to remove duplication. Github::Issue.list is left; when GitLab issue listing will be implemented, it may be removed, depending on the GitLab structure.

Addresses first point of #67