### PR TITLE
Fix `issues list --upstream` error

### DIFF
--- a/lib/geet/services/list_issues.rb
+++ b/lib/geet/services/list_issues.rb
@@ -3,7 +3,7 @@
 module Geet
   module Services
     class ListIssues
-      def execute(repository, assignee_pattern: nil, output: $stdout)
+      def execute(repository, assignee_pattern: nil, output: $stdout, **)
         assignee_thread = find_assignee(repository, assignee_pattern, output) if assignee_pattern
 
         assignee = assignee_thread&.join&.value


### PR DESCRIPTION
The new `upstream` parameters needed to be ignored.