### PR TITLE
Don't assign authenticated user by default when creating an issue upstream

### DIFF
--- a/lib/geet/commandline/configuration.rb
+++ b/lib/geet/commandline/configuration.rb
@@ -24,7 +24,7 @@ module Geet
         ['-n', '--no-open-issue',                           "Don't open the issue link in the browser after creation"],
         ['-l', '--label-patterns "bug,help wanted"',        'Label patterns'],
         ['-m', '--milestone 1.5.0',                         'Milestone title pattern'],
-        ['-a', '--assignee-patterns john,tom,adrian,kevin', 'Assignee login patterns. Defaults to authenticated user'],
+        ['-a', '--assignee-patterns john,tom,adrian,kevin', 'Assignee login patterns'],
         ['-u', '--upstream',                                'Create on the upstream repository'],
         long_help: 'The default editor will be opened for editing title and description.'
       ]

--- a/lib/geet/git/repository.rb
+++ b/lib/geet/git/repository.rb
@@ -94,6 +94,10 @@ module Geet
         branch
       end
 
+      def upstream?
+        @upstream
+      end
+
       private
 
       # REPOSITORY METADATA

--- a/lib/geet/services/create_issue.rb
+++ b/lib/geet/services/create_issue.rb
@@ -82,13 +82,13 @@ module Geet
 
         if assignees
           assign_users_thread = assign_users(issue, assignees, output)
-        else
+        elsif !repository.upstream?
           assign_users_thread = assign_authenticated_user(repository, issue, output)
         end
 
         add_labels_thread&.join
         set_milestone_thread&.join
-        assign_users_thread.join
+        assign_users_thread&.join
       end
 
       def add_labels(issue, selected_labels, output)

--- a/spec/integration/create_issue_spec.rb
+++ b/spec/integration/create_issue_spec.rb
@@ -49,7 +49,6 @@ describe Geet::Services::CreateIssue do
 
     expected_output = <<~STR
       Creating the issue...
-      Assigning authenticated user...
       Issue address: https://github.com/donald-fr/testrepo_u/issues/7
     STR
 


### PR DESCRIPTION
The regular case, when creating an issue upstream, is that the ownwers will assign it, not the issue creator.