### PR TITLE
Extract the git client code from Repository into the GitClient class

### DIFF
--- a/bin/geet
+++ b/bin/geet
@@ -5,7 +5,7 @@ require_relative '../lib/geet/commandline/configuration.rb'
 require_relative '../lib/geet/commandline/commands.rb'
 require_relative '../lib/geet/commandline/editor.rb'
 require_relative '../lib/geet/git/repository.rb'
-require_relative '../lib/geet/utils/git.rb'
+require_relative '../lib/geet/utils/git_client.rb'
 Dir[File.join(__dir__, '../lib/geet/services/*.rb')].each { |filename| require filename }
 
 class GeetLauncher
@@ -59,7 +59,7 @@ class GeetLauncher
   def edit_pr_title_and_description(repository)
     # Tricky. It would be best to have Git logic exlusively inside the services,
     # but at the same time, the summary editing should be out.
-    git = Utils::Git.new(repository)
+    git = Utils::GitClient.new(repository)
     pr_commits = git.cherry('master')
 
     if pr_commits.size == 1

--- a/lib/geet/git/repository.rb
+++ b/lib/geet/git/repository.rb
@@ -150,7 +150,7 @@ module Geet
 
         domain = remote_url[REMOTE_ORIGIN_REGEX, 1] || remote_url[REMOTE_ORIGIN_REGEX, 2]
 
-        raise "Can't identify domain in the provider domain string: #{provider_domain}" if domain !~ /(.*)\.\w+/
+        raise "Can't identify domain in the provider domain string: #{domain}" if domain !~ /(.*)\.\w+/
 
         domain
       end

--- a/lib/geet/utils/git_client.rb
+++ b/lib/geet/utils/git_client.rb
@@ -6,7 +6,7 @@ module Geet
   module Utils
     # Represents the git program interface; used for performing git operations.
     #
-    class Git
+    class GitClient
       def initialize(repository)
         @repository = repository
       end

--- a/lib/geet/utils/git_client.rb
+++ b/lib/geet/utils/git_client.rb
@@ -7,8 +7,20 @@ module Geet
     # Represents the git program interface; used for performing git operations.
     #
     class GitClient
-      def initialize(repository)
-        @repository = repository
+      ORIGIN_NAME   = 'origin'
+      UPSTREAM_NAME = 'upstream'
+
+      # For simplicity, we match any character except the ones the separators.
+      REMOTE_ORIGIN_REGEX = %r{
+        \A
+        (?:https://(.+?)/|git@(.+?):)
+        ([^/]+/.*?)
+        (?:\.git)?
+        \Z
+      }x
+
+      def initialize(location: nil)
+        @location = location
       end
 
       # Return the commit shas between HEAD and `limit`, excluding the already applied commits
@@ -18,6 +30,64 @@ module Geet
         raw_commits = `git cherry #{limit.shellescape}`.strip
 
         raw_commits.split("\n").grep(/^\+/).map { |line| line[3..-1] }
+      end
+
+      def current_branch
+        gitdir_option = "--git-dir #{location.shellescape}/.git" if location
+        branch = `git #{gitdir_option} rev-parse --abbrev-ref HEAD`.strip
+
+        raise "Couldn't find current branch" if branch == 'HEAD'
+
+        branch
+      end
+
+      # Example: `donaldduck/geet`
+      #
+      def path(upstream: false)
+        remote_name = upstream ? UPSTREAM_NAME : ORIGIN_NAME
+
+        remote(remote_name)[REMOTE_ORIGIN_REGEX, 3]
+      end
+
+      def provider_domain
+        # We assume that it's not possible to have origin and upstream on different providers.
+        #
+        remote_url = remote(ORIGIN_NAME)
+
+        domain = remote_url[REMOTE_ORIGIN_REGEX, 1] || remote_url[REMOTE_ORIGIN_REGEX, 2]
+
+        raise "Can't identify domain in the provider domain string: #{domain}" if domain !~ /(.*)\.\w+/
+
+        domain
+      end
+
+      # Returns the URL of the remote with the given name.
+      # Sanity checks are performed.
+      #
+      # The result is in the format `git@github.com:donaldduck/geet.git`
+      #
+      def remote(name)
+        gitdir_option = "--git-dir #{@location.shellescape}/.git" if @location
+        remote_url = `git #{gitdir_option} ls-remote --get-url #{name}`.strip
+
+        if remote_url == name
+          raise "Remote #{name.inspect} not found!"
+        elsif remote_url !~ REMOTE_ORIGIN_REGEX
+          raise "Unexpected remote reference format: #{remote_url.inspect}"
+        end
+
+        remote_url
+      end
+
+      # Doesn't sanity check for the remote url format; this action is for querying
+      # purposes, any any action that needs to work with the remote, uses #remote.
+      #
+      def remote_defined?(name)
+        gitdir_option = "--git-dir #{@location.shellescape}/.git" if @location
+        remote_url = `git #{gitdir_option} ls-remote --get-url #{name}`.strip
+
+        # If the remote is not define, `git ls-remote` will return the passed value.
+        remote_url != name
       end
 
       # Show the description ("<subject>\n\n<body>") for the given git object.

--- a/spec/integration/create_issue_spec.rb
+++ b/spec/integration/create_issue_spec.rb
@@ -6,12 +6,13 @@ require_relative '../../lib/geet/git/repository'
 require_relative '../../lib/geet/services/create_issue'
 
 describe Geet::Services::CreateIssue do
-  let(:repository) { Geet::Git::Repository.new }
-  let(:upstream_repository) { Geet::Git::Repository.new(upstream: true) }
+  let(:git_client) { Geet::Utils::GitClient.new }
+  let(:repository) { Geet::Git::Repository.new(git_client: git_client) }
+  let(:upstream_repository) { Geet::Git::Repository.new(upstream: true, git_client: git_client) }
 
   context 'with labels, assignees and milestones' do
     it 'should create an issue' do
-      allow(repository).to receive(:remote).with('origin').and_return('git@github.com:donaldduck/testrepo')
+      allow(git_client).to receive(:remote).with('origin').and_return('git@github.com:donaldduck/testrepo')
 
       expected_output = <<~STR
         Finding labels...
@@ -43,9 +44,9 @@ describe Geet::Services::CreateIssue do
   end
 
   it 'should create an upstream issue' do
-    allow(upstream_repository).to receive(:current_branch).and_return('mybranch')
-    allow(upstream_repository).to receive(:remote).with('origin').and_return('git@github.com:donaldduck/testrepo')
-    allow(upstream_repository).to receive(:remote).with('upstream').and_return('git@github.com:donald-fr/testrepo_u')
+    allow(git_client).to receive(:current_branch).and_return('mybranch')
+    allow(git_client).to receive(:remote).with('origin').and_return('git@github.com:donaldduck/testrepo')
+    allow(git_client).to receive(:remote).with('upstream').and_return('git@github.com:donald-fr/testrepo_u')
 
     expected_output = <<~STR
       Creating the issue...

--- a/spec/integration/create_label_spec.rb
+++ b/spec/integration/create_label_spec.rb
@@ -6,11 +6,12 @@ require_relative '../../lib/geet/git/repository'
 require_relative '../../lib/geet/services/create_label'
 
 describe Geet::Services::CreateLabel do
-  let(:repository) { Geet::Git::Repository.new }
+  let(:git_client) { Geet::Utils::GitClient.new }
+  let(:repository) { Geet::Git::Repository.new(git_client: git_client) }
 
   context 'with user-specified color' do
     it 'should create a label' do
-      allow(repository).to receive(:remote).with('origin').and_return('git@github.com:donaldduck/testrepo')
+      allow(git_client).to receive(:remote).with('origin').and_return('git@github.com:donaldduck/testrepo')
 
       expected_output = <<~STR
         Creating label...
@@ -32,7 +33,7 @@ describe Geet::Services::CreateLabel do
 
   context 'with auto-generated color' do
     it 'should create a label' do
-      allow(repository).to receive(:remote).with('origin').and_return('git@github.com:donaldduck/testrepo')
+      allow(git_client).to receive(:remote).with('origin').and_return('git@github.com:donaldduck/testrepo')
 
       expected_output_template = <<~STR
         Creating label...

--- a/spec/integration/create_pr_spec.rb
+++ b/spec/integration/create_pr_spec.rb
@@ -6,13 +6,14 @@ require_relative '../../lib/geet/git/repository'
 require_relative '../../lib/geet/services/create_pr'
 
 describe Geet::Services::CreatePr do
-  let(:repository) { Geet::Git::Repository.new }
-  let(:upstream_repository) { Geet::Git::Repository.new(upstream: true) }
+  let(:git_client) { Geet::Utils::GitClient.new }
+  let(:repository) { Geet::Git::Repository.new(git_client: git_client) }
+  let(:upstream_repository) { Geet::Git::Repository.new(upstream: true, git_client: git_client) }
 
   context 'with labels, reviewers and milestones' do
     it 'should create a PR' do
-      allow(repository).to receive(:current_branch).and_return('mybranch1')
-      allow(repository).to receive(:remote).with('origin').and_return('git@github.com:donaldduck/testrepo')
+      allow(git_client).to receive(:current_branch).and_return('mybranch1')
+      allow(git_client).to receive(:remote).with('origin').and_return('git@github.com:donaldduck/testrepo')
 
       expected_output = <<~STR
         Finding labels...
@@ -45,9 +46,9 @@ describe Geet::Services::CreatePr do
   end
 
   it 'should create an upstream PR' do
-    allow(upstream_repository).to receive(:current_branch).and_return('mybranch')
-    allow(upstream_repository).to receive(:remote).with('origin').and_return('git@github.com:donaldduck/testrepo_2f')
-    allow(upstream_repository).to receive(:remote).with('upstream').and_return('git@github.com:donald-fr/testrepo_u')
+    allow(git_client).to receive(:current_branch).and_return('mybranch')
+    allow(git_client).to receive(:remote).with('origin').and_return('git@github.com:donaldduck/testrepo_2f')
+    allow(git_client).to receive(:remote).with('upstream').and_return('git@github.com:donald-fr/testrepo_u')
 
     expected_output = <<~STR
       Creating PR...

--- a/spec/integration/list_issues_spec.rb
+++ b/spec/integration/list_issues_spec.rb
@@ -6,12 +6,13 @@ require_relative '../../lib/geet/git/repository'
 require_relative '../../lib/geet/services/list_issues'
 
 describe Geet::Services::ListIssues do
-  let(:repository) { Geet::Git::Repository.new }
-  let(:upstream_repository) { Geet::Git::Repository.new(upstream: true) }
+  let(:git_client) { Geet::Utils::GitClient.new }
+  let(:repository) { Geet::Git::Repository.new(git_client: git_client) }
+  let(:upstream_repository) { Geet::Git::Repository.new(upstream: true, git_client: git_client) }
 
   context 'with github.com' do
     it 'should list the default issues' do
-      allow(repository).to receive(:remote).with('origin').and_return('git@github.com:donaldduck/testrepo')
+      allow(git_client).to receive(:remote).with('origin').and_return('git@github.com:donaldduck/testrepo')
 
       expected_output = <<~STR
         5. Title 2 (https://github.com/donaldduck/testrepo/issues/5)
@@ -33,7 +34,7 @@ describe Geet::Services::ListIssues do
 
     context 'with assignee filtering' do
       it 'should list the issues' do
-        allow(repository).to receive(:remote).with('origin').and_return('git@github.com:donaldduck/testrepo_gh')
+        allow(git_client).to receive(:remote).with('origin').and_return('git@github.com:donaldduck/testrepo_gh')
 
         expected_output = <<~STR
           Finding assignee...
@@ -56,8 +57,8 @@ describe Geet::Services::ListIssues do
     end
 
     it 'should list the upstream issues' do
-      allow(upstream_repository).to receive(:remote).with('origin').and_return('git@github.com:donaldduck/testrepo_2f')
-      allow(upstream_repository).to receive(:remote).with('upstream').and_return('git@github.com:donald-fr/testrepo_u')
+      allow(git_client).to receive(:remote).with('origin').and_return('git@github.com:donaldduck/testrepo_2f')
+      allow(git_client).to receive(:remote).with('upstream').and_return('git@github.com:donald-fr/testrepo_u')
 
       expected_output = <<~STR
         2. Title 2 U (https://github.com/donald-fr/testrepo_u/issues/2)
@@ -80,7 +81,7 @@ describe Geet::Services::ListIssues do
 
   context 'with gitlab.com' do
     it 'should list the issues' do
-      allow(repository).to receive(:remote).with('origin').and_return('git@gitlab.com:donaldduck/testproject')
+      allow(git_client).to receive(:remote).with('origin').and_return('git@gitlab.com:donaldduck/testproject')
 
       expected_output = <<~STR
         2. I like more pizza (https://gitlab.com/donaldduck/testproject/issues/2)

--- a/spec/integration/list_labels_spec.rb
+++ b/spec/integration/list_labels_spec.rb
@@ -6,11 +6,12 @@ require_relative '../../lib/geet/git/repository'
 require_relative '../../lib/geet/services/list_labels'
 
 describe Geet::Services::ListLabels do
-  let(:repository) { Geet::Git::Repository.new }
+  let(:git_client) { Geet::Utils::GitClient.new }
+  let(:repository) { Geet::Git::Repository.new(git_client: git_client) }
 
   context 'with github.com' do
     it 'should list the labels' do
-      allow(repository).to receive(:remote).with('origin').and_return('git@github.com:donaldduck/geet')
+      allow(git_client).to receive(:remote).with('origin').and_return('git@github.com:donaldduck/geet')
 
       expected_output = <<~STR
         - bug (#ee0701)
@@ -34,7 +35,7 @@ describe Geet::Services::ListLabels do
 
   context 'with gitlab.com' do
     it 'should list the labels' do
-      allow(repository).to receive(:remote).with('origin').and_return('git@gitlab.com:donaldduck/testproject')
+      allow(git_client).to receive(:remote).with('origin').and_return('git@gitlab.com:donaldduck/testproject')
 
       expected_output = <<~STR
         - bug (#d9534f)

--- a/spec/integration/list_milestones_spec.rb
+++ b/spec/integration/list_milestones_spec.rb
@@ -6,10 +6,11 @@ require_relative '../../lib/geet/git/repository'
 require_relative '../../lib/geet/services/list_milestones'
 
 describe Geet::Services::ListMilestones do
-  let(:repository) { Geet::Git::Repository.new }
+  let(:git_client) { Geet::Utils::GitClient.new }
+  let(:repository) { Geet::Git::Repository.new(git_client: git_client) }
 
   it 'should list the milestones' do
-    allow(repository).to receive(:remote).with('origin').and_return('git@github.com:donaldduck/geet')
+    allow(git_client).to receive(:remote).with('origin').and_return('git@github.com:donaldduck/geet')
 
     expected_output = <<~STR
       Finding milestones...

--- a/spec/integration/list_prs_spec.rb
+++ b/spec/integration/list_prs_spec.rb
@@ -6,11 +6,12 @@ require_relative '../../lib/geet/git/repository'
 require_relative '../../lib/geet/services/list_prs'
 
 describe Geet::Services::ListPrs do
-  let(:repository) { Geet::Git::Repository.new }
-  let(:upstream_repository) { Geet::Git::Repository.new(upstream: true) }
+  let(:git_client) { Geet::Utils::GitClient.new }
+  let(:repository) { Geet::Git::Repository.new(git_client: git_client) }
+  let(:upstream_repository) { Geet::Git::Repository.new(upstream: true, git_client: git_client) }
 
   it 'should list the PRs' do
-    allow(repository).to receive(:remote).with('origin').and_return('git@github.com:donaldduck/testrepo')
+    allow(git_client).to receive(:remote).with('origin').and_return('git@github.com:donaldduck/testrepo')
 
     expected_output = <<~STR
       6. Title 2 (https://github.com/donaldduck/testrepo/pull/6)
@@ -31,8 +32,8 @@ describe Geet::Services::ListPrs do
   end
 
   it 'should list the upstream PRs' do
-    allow(upstream_repository).to receive(:remote).with('origin').and_return('git@github.com:donaldduck/testrepo_2f')
-    allow(upstream_repository).to receive(:remote).with('upstream').and_return('git@github.com:donald-fr/testrepo_u')
+    allow(git_client).to receive(:remote).with('origin').and_return('git@github.com:donaldduck/testrepo_2f')
+    allow(git_client).to receive(:remote).with('upstream').and_return('git@github.com:donald-fr/testrepo_u')
 
     expected_output = <<~STR
       5. Title 2 (https://github.com/donald-fr/testrepo_u/pull/5)

--- a/spec/integration/merge_pr_spec.rb
+++ b/spec/integration/merge_pr_spec.rb
@@ -6,11 +6,12 @@ require_relative '../../lib/geet/git/repository'
 require_relative '../../lib/geet/services/merge_pr'
 
 describe Geet::Services::MergePr do
-  let(:repository) { Geet::Git::Repository.new }
+  let(:git_client) { Geet::Utils::GitClient.new }
+  let(:repository) { Geet::Git::Repository.new(git_client: git_client) }
 
   it 'should merge the PR for the current branch' do
-    allow(repository).to receive(:current_branch).and_return('mybranch1')
-    allow(repository).to receive(:remote).with('origin').and_return('git@github.com:donaldduck/testrepo')
+    allow(git_client).to receive(:current_branch).and_return('mybranch1')
+    allow(git_client).to receive(:remote).with('origin').and_return('git@github.com:donaldduck/testrepo')
 
     expected_output = <<~STR
       Finding PR with head (mybranch1)...
@@ -31,8 +32,8 @@ describe Geet::Services::MergePr do
   end
 
   it 'should merge the PR for the current branch, with branch deletion' do
-    allow(repository).to receive(:current_branch).and_return('mybranch')
-    allow(repository).to receive(:remote).with('origin').and_return('git@github.com:donaldduck/testrepo')
+    allow(git_client).to receive(:current_branch).and_return('mybranch')
+    allow(git_client).to receive(:remote).with('origin').and_return('git@github.com:donaldduck/testrepo')
 
     expected_output = <<~STR
       Finding PR with head (mybranch)...


### PR DESCRIPTION
Beside making the Repository class cleaner, it also simplifies testing the services.

Closes #79.