### PR TITLE
Decouple Gist (creation) from Repository

### DIFF
--- a/bin/geet
+++ b/bin/geet
@@ -23,7 +23,7 @@ class GeetLauncher
       filename = options.delete(:filename)
       options[:publik] = options.delete(:public) if options.key?(:public)
 
-      Services::CreateGist.new.execute(repository, filename, options)
+      Services::CreateGist.new.execute(filename, options)
     when ISSUE_CREATE_COMMAND
       title, description = Commandline::Editor.new.edit_summary
       options[:milestone_pattern] = options.delete(:milestone) if options.key?(:milestone)

--- a/lib/geet/git/repository.rb
+++ b/lib/geet/git/repository.rb
@@ -132,7 +132,7 @@ module Geet
 
       def api_interface
         path = @git_client.path(upstream: @upstream)
-        attempt_provider_call(:ApiInterface, :new, @api_token, path, @upstream)
+        attempt_provider_call(:ApiInterface, :new, @api_token, repo_path: path, upstream: @upstream)
       end
 
       def ask_confirm_action

--- a/lib/geet/git/repository.rb
+++ b/lib/geet/git/repository.rb
@@ -31,10 +31,6 @@ module Geet
         attempt_provider_call(:Label, :list, api_interface)
       end
 
-      def create_gist(filename, content, description: nil, publik: false)
-        attempt_provider_call(:Gist, :create, filename, content, api_interface, description: description, publik: publik)
-      end
-
       def create_issue(title, description)
         ask_confirm_action if local_action_with_upstream_repository?
         attempt_provider_call(:Issue, :create, title, description, api_interface)

--- a/lib/geet/github/api_interface.rb
+++ b/lib/geet/github/api_interface.rb
@@ -11,9 +11,12 @@ module Geet
       API_AUTH_USER = '' # We don't need the login, as the API key uniquely identifies the user
       API_BASE_URL = 'https://api.github.com'
 
-      def initialize(api_token, repository_path, upstream)
+      # repo_path: optional for operations that don't require a repository, eg. gist creation.
+      # upstream:  boolean; makes sense only when :repo_path is set.
+      #
+      def initialize(api_token, repo_path: nil, upstream: nil)
         @api_token = api_token
-        @repository_path = repository_path
+        @repository_path = repo_path
         @upstream = upstream
       end
 
@@ -69,7 +72,12 @@ module Geet
 
       def api_url(api_path)
         url = API_BASE_URL
-        url += "/repos/#{@repository_path}/" if !api_path.start_with?('/')
+
+        if !api_path.start_with?('/')
+          raise 'Missing repo path!' if @repository_path.nil?
+          url += "/repos/#{@repository_path}/"
+        end
+
         url + api_path
       end
 

--- a/lib/geet/github/gist.rb
+++ b/lib/geet/github/gist.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'abstract_issue'
+require_relative '../github/gist'
 
 module Geet
   module Github

--- a/lib/geet/gitlab/api_interface.rb
+++ b/lib/geet/gitlab/api_interface.rb
@@ -11,9 +11,12 @@ module Geet
     class ApiInterface
       API_BASE_URL = 'https://gitlab.com/api/v4'
 
-      def initialize(api_token, path_with_namespace, upstream)
+      # repo_path: "path/namespace"; required for the current GitLab operations.
+      # upstream:  boolean; required for the current GitLab operations.
+      #
+      def initialize(api_token, repo_path:, upstream:)
         @api_token = api_token
-        @path_with_namespace = path_with_namespace
+        @path_with_namespace = repo_path
         @upstream = upstream
       end
 

--- a/lib/geet/services/create_gist.rb
+++ b/lib/geet/services/create_gist.rb
@@ -1,31 +1,47 @@
 # frozen_string_literal: true
 
 require_relative '../helpers/os_helper.rb'
+require_relative '../github/api_interface.rb'
+require_relative '../github/gist.rb'
 
 module Geet
   module Services
     class CreateGist
       include Geet::Helpers::OsHelper
 
+      API_TOKEN_KEY = 'GITHUB_API_TOKEN'
+      DEFAULT_GIT_CLIENT = Geet::Utils::GitClient.new
+
+      def initialize
+        api_token = extract_env_api_token
+        @api_interface = Geet::Github::ApiInterface.new(api_token)
+      end
+
       # options:
       #   :description
       #   :publik:      defaults to false
       #   :no_browse    defaults to false
       #
-      def execute(repository, full_filename, description: nil, publik: false, no_browse: false, output: $stdout)
+      def execute(full_filename, description: nil, publik: false, no_browse: false, output: $stdout)
         content = IO.read(full_filename)
 
         gist_access = publik ? 'public' : 'private'
         output.puts "Creating a #{gist_access} gist..."
 
         filename = File.basename(full_filename)
-        gist = repository.create_gist(filename, content, description: description, publik: publik)
+        gist = Geet::Github::Gist.create(filename, content, @api_interface, description: description, publik: publik)
 
         if no_browse
           output.puts "Gist address: #{gist.link}"
         else
           open_file_with_default_application(gist.link)
         end
+      end
+
+      private
+
+      def extract_env_api_token
+        ENV[API_TOKEN_KEY] || raise("#{API_TOKEN_KEY} not set!")
       end
     end
   end

--- a/spec/integration/create_gist_spec.rb
+++ b/spec/integration/create_gist_spec.rb
@@ -7,7 +7,6 @@ require_relative '../../lib/geet/git/repository'
 require_relative '../../lib/geet/services/create_gist'
 
 describe Geet::Services::CreateGist do
-  let(:repository) { Geet::Git::Repository.new }
   let(:tempfile) { Tempfile.open('geet_gist') { |file| file << 'testcontent' } }
 
   it 'should create a public gist' do
@@ -20,8 +19,7 @@ describe Geet::Services::CreateGist do
 
     VCR.use_cassette('create_gist_public') do
       described_class.new.execute(
-        repository, tempfile.path,
-        description: 'testdescription', publik: true, no_browse: true, output: actual_output
+        tempfile.path, description: 'testdescription', publik: true, no_browse: true, output: actual_output
       )
     end
 
@@ -38,8 +36,7 @@ describe Geet::Services::CreateGist do
 
     VCR.use_cassette('create_gist_private') do
       described_class.new.execute(
-        repository, tempfile.path,
-        description: 'testdescription', no_browse: true, output: actual_output
+        tempfile.path, description: 'testdescription', no_browse: true, output: actual_output
       )
     end
 


### PR DESCRIPTION
It's not necessary to have a repository when creating a Gist; it was existing only for uniformity reasons, which can be easily "worked around" (still in a clean way).

Closes #35.