### PR TITLE
Allow not choosing entries on selection menus

### DIFF
--- a/lib/geet/services/create_issue.rb
+++ b/lib/geet/services/create_issue.rb
@@ -91,11 +91,14 @@ module Geet
       end
 
       def edit_issue(issue, labels, milestone, assignees, output)
-        add_labels_thread = add_labels(issue, labels, output) if labels
+        # labels can be nil (parameter not passed) or empty array (parameter passed, but nothing
+        # selected)
+        add_labels_thread = add_labels(issue, labels, output) if labels && !labels.empty?
         set_milestone_thread = set_milestone(issue, milestone, output) if milestone
 
+        # same considerations as above, but with additional upstream case.
         if assignees
-          assign_users_thread = assign_users(issue, assignees, output)
+          assign_users_thread = assign_users(issue, assignees, output) if !assignees.empty?
         elsif !@repository.upstream?
           assign_users_thread = assign_authenticated_user(issue, output)
         end

--- a/lib/geet/services/create_issue.rb
+++ b/lib/geet/services/create_issue.rb
@@ -35,7 +35,7 @@ module Geet
 
         labels = select_entries('label', all_labels, label_patterns, :multiple, :name) if label_patterns
         milestone, _ = select_entries('milestone', all_milestones, milestone_pattern, :single, :title) if milestone_pattern
-        assignees = select_entries('collaborator', all_collaborators, assignee_patterns, :multiple, nil) if assignee_patterns
+        assignees = select_entries('assignee', all_collaborators, assignee_patterns, :multiple, nil) if assignee_patterns
 
         issue = create_issue(title, description, output)
 

--- a/lib/geet/services/create_pr.rb
+++ b/lib/geet/services/create_pr.rb
@@ -94,9 +94,11 @@ module Geet
       def edit_pr(pr, labels, milestone, reviewers, output)
         assign_user_thread = assign_authenticated_user(pr, output)
 
-        add_labels_thread = add_labels(pr, labels, output) if labels
+        # labels/reviewers can be nil (parameter not passed) or empty array (parameter passed, but
+        # nothing selected)
+        add_labels_thread = add_labels(pr, labels, output) if labels && !labels.empty?
         set_milestone_thread = set_milestone(pr, milestone, output) if milestone
-        request_review_thread = request_review(pr, reviewers, output) if reviewers
+        request_review_thread = request_review(pr, reviewers, output) if reviewers && !reviewers.empty?
 
         assign_user_thread.join
         add_labels_thread&.join

--- a/lib/geet/services/create_pr.rb
+++ b/lib/geet/services/create_pr.rb
@@ -36,7 +36,7 @@ module Geet
 
         labels = select_entries('label', all_labels, label_patterns, :multiple, :name) if label_patterns
         milestone, _ = select_entries('milestone', all_milestones, milestone_pattern, :single, :title) if milestone_pattern
-        reviewers = select_entries('collaborator', all_collaborators, reviewer_patterns, :multiple, nil) if reviewer_patterns
+        reviewers = select_entries('reviewer', all_collaborators, reviewer_patterns, :multiple, nil) if reviewer_patterns
 
         pr = create_pr(title, description, output)
 

--- a/lib/geet/utils/manual_list_selection.rb
+++ b/lib/geet/utils/manual_list_selection.rb
@@ -5,6 +5,8 @@ require 'temp-fork-tp-filter'
 module Geet
   module Utils
     class ManualListSelection
+      NO_SELECTION_KEY = '(none)'
+
       PAGER_SIZE = 16
 
       # entry_type:      description of the entries type.
@@ -14,14 +16,17 @@ module Geet
       # instance_method: required when non-string objects are passed as entries; its invocation on
       #                  each object must return a string, which is used as key.
       #
-      # returns: the selected entry or array of entries.
+      # returns: the selected entry or array of entries. for single selection, if no entries are
+      #          chosen, nil is returned.
       #
       def select(entry_type, entries, selection_type, instance_method: nil)
         check_entries(entries)
 
-        entries = map_entries_to_objects(entries, instance_method) if instance_method
+        entries = create_entries_map(entries, instance_method)
 
-        show_prompt(entry_type, selection_type, entries)
+        result = show_prompt(entry_type, selection_type, entries)
+
+        result
       end
 
       private
@@ -30,9 +35,10 @@ module Geet
         raise "No #{entry_type} provided!" if entries.empty?
       end
 
-      def map_entries_to_objects(entries, instance_method)
+      def create_entries_map(entries, instance_method)
         entries.each_with_object({}) do |entry, current_map|
-          current_map[entry.send(instance_method)] = entry
+          key = instance_method ? entry.send(instance_method) : entry
+          current_map[key] = entry
         end
       end
 
@@ -41,12 +47,17 @@ module Geet
 
         case selection_type
         when :single
+          entries = add_no_selection_entry(entries)
           TTY::Prompt.new.select(prompt_title, entries, filter: true, per_page: PAGER_SIZE)
         when :multiple
           TTY::Prompt.new.multi_select(prompt_title, entries, filter: true, per_page: PAGER_SIZE)
         else
           raise "Unexpected selection type: #{selection_type.inspect}"
         end
+      end
+
+      def add_no_selection_entry(entries)
+        {NO_SELECTION_KEY => nil}.merge(entries)
       end
     end
   end

--- a/lib/geet/utils/manual_list_selection.rb
+++ b/lib/geet/utils/manual_list_selection.rb
@@ -7,39 +7,46 @@ module Geet
     class ManualListSelection
       PAGER_SIZE = 16
 
-      PROMPT_METHODS = {
-        single: :select,
-        multiple: :multi_select,
-      }
-
-      # selection_type: :single or :multiple
+      # entry_type:      description of the entries type.
+      # entries:         array of objects; if they're not strings, must also pass :instance_method.
+      #                  this value must not be empty.
+      # selection_type:  :single or :multiple
+      # instance_method: required when non-string objects are passed as entries; its invocation on
+      #                  each object must return a string, which is used as key.
+      #
+      # returns: the selected entry or array of entries.
+      #
       def select(entry_type, entries, selection_type, instance_method: nil)
-        raise "No #{entry_type} provided!" if entries.empty?
+        check_entries(entries)
 
-        prompt_method = find_prompt_method(selection_type)
-        prompt_title = "Please select the #{entry_type}(s):"
+        entries = map_entries_to_objects(entries, instance_method) if instance_method
 
-        if instance_method
-          entries = entries.each_with_object({}) do |entry, current_map|
-            current_map[entry.send(instance_method)] = entry
-          end
-        end
-
-        selected_entries = TTY::Prompt.new.send(prompt_method, prompt_title, entries, filter: true, per_page: PAGER_SIZE)
-
-        if selected_entries.is_a?(Array)
-          raise "No #{entry_type} selected!" if selected_entries.empty?
-        else
-          raise "No #{entry_type} selected!" if selected_entries.nil?
-        end
-
-        selected_entries
+        show_prompt(entry_type, selection_type, entries)
       end
 
       private
 
-      def find_prompt_method(selection_type)
-        PROMPT_METHODS[selection_type] || raise("Unrecognized selection_type: #{selection_type}")
+      def check_entries(entries)
+        raise "No #{entry_type} provided!" if entries.empty?
+      end
+
+      def map_entries_to_objects(entries, instance_method)
+        entries.each_with_object({}) do |entry, current_map|
+          current_map[entry.send(instance_method)] = entry
+        end
+      end
+
+      def show_prompt(entry_type, selection_type, entries)
+        prompt_title = "Please select the #{entry_type}(s):"
+
+        case selection_type
+        when :single
+          TTY::Prompt.new.select(prompt_title, entries, filter: true, per_page: PAGER_SIZE)
+        when :multiple
+          TTY::Prompt.new.multi_select(prompt_title, entries, filter: true, per_page: PAGER_SIZE)
+        else
+          raise "Unexpected selection type: #{selection_type.inspect}"
+        end
       end
     end
   end


### PR DESCRIPTION
The user is not forced anymore to choose entries in selection menus.

A '(none)' entry is automatically added on top, for quick selection with Enter:

    Please select the milestone(s): (Use arrow keys, press Enter to select, and alphanumeric/underscore characters to filter)
    ‣ (none)
      milestone 1
      milestone 2

Closes #96.