### PR TITLE
Add `--summary` commandline option to PR/Issue creation

### DIFF
--- a/bin/geet
+++ b/bin/geet
@@ -28,7 +28,7 @@ class GeetLauncher
 
       Services::CreateGist.new.execute(filename, options)
     when ISSUE_CREATE_COMMAND
-      summary = Commandline::Editor.new.edit_content(help: SUMMARY_TEMPLATE)
+      summary = options[:summary] || Commandline::Editor.new.edit_content(help: SUMMARY_TEMPLATE)
       title, description = split_summary(summary)
 
       options[:milestone_pattern] = options.delete(:milestone) if options.key?(:milestone)
@@ -45,7 +45,7 @@ class GeetLauncher
     when MILESTONE_LIST_COMMAND
       Services::ListMilestones.new(repository).execute
     when PR_CREATE_COMMAND
-      summary = edit_pr_summary
+      summary = options[:summary] || edit_pr_summary
       title, description = split_summary(summary)
 
       options[:milestone_pattern] = options.delete(:milestone) if options.key?(:milestone)

--- a/bin/geet
+++ b/bin/geet
@@ -5,12 +5,16 @@ require_relative '../lib/geet/commandline/configuration.rb'
 require_relative '../lib/geet/commandline/commands.rb'
 require_relative '../lib/geet/commandline/editor.rb'
 require_relative '../lib/geet/git/repository.rb'
+require_relative '../lib/geet/helpers/summary_helper.rb'
 require_relative '../lib/geet/utils/git_client.rb'
 Dir[File.join(__dir__, '../lib/geet/services/*.rb')].each { |filename| require filename }
 
 class GeetLauncher
   include Geet
   include Geet::Commandline::Commands
+  include Geet::Helpers::SummaryHelper
+
+  SUMMARY_TEMPLATE = IO.read(File.expand_path('../lib/geet/resources/templates/edit_summary.md', __dir__))
 
   def launch
     command, options = Commandline::Configuration.new.decode_argv || exit
@@ -24,7 +28,9 @@ class GeetLauncher
 
       Services::CreateGist.new.execute(filename, options)
     when ISSUE_CREATE_COMMAND
-      title, description = Commandline::Editor.new.edit_summary
+      summary = Commandline::Editor.new.edit_content(help: SUMMARY_TEMPLATE)
+      title, description = split_summary(summary)
+
       options[:milestone_pattern] = options.delete(:milestone) if options.key?(:milestone)
 
       Services::CreateIssue.new(repository).execute(title, description, options)
@@ -39,7 +45,8 @@ class GeetLauncher
     when MILESTONE_LIST_COMMAND
       Services::ListMilestones.new(repository).execute
     when PR_CREATE_COMMAND
-      title, description = edit_pr_title_and_description
+      summary = edit_pr_summary
+      title, description = split_summary(summary)
 
       options[:milestone_pattern] = options.delete(:milestone) if options.key?(:milestone)
 
@@ -55,7 +62,7 @@ class GeetLauncher
 
   private
 
-  def edit_pr_title_and_description
+  def edit_pr_summary
     # Tricky. It would be best to have Git logic exlusively inside the services,
     # but at the same time, the summary editing should be out.
     git = Utils::GitClient.new
@@ -64,9 +71,11 @@ class GeetLauncher
     if pr_commits.size == 1
       prepopulated_summary = git.show_description('HEAD')
       cancel_pr_help = "In order to cancel the PR creation, delete the description above.\n"
-    end
 
-    Commandline::Editor.new.edit_summary(summary: prepopulated_summary, extra_help: cancel_pr_help)
+      Commandline::Editor.new.edit_content(content: prepopulated_summary, help: SUMMARY_TEMPLATE + cancel_pr_help)
+    else
+      Commandline::Editor.new.edit_content(help: SUMMARY_TEMPLATE)
+    end
   end
 end
 

--- a/lib/geet/commandline/configuration.rb
+++ b/lib/geet/commandline/configuration.rb
@@ -25,6 +25,7 @@ module Geet
         ['-l', '--label-patterns "bug,help wanted"',        'Label patterns'],
         ['-m', '--milestone 1.5.0',                         'Milestone title pattern'],
         ['-a', '--assignee-patterns john,tom,adrian,kevin', 'Assignee login patterns'],
+        ['-s', '--summary title_and_description',           'Set the summary (title and optionally description'],
         ['-u', '--upstream',                                'Create on the upstream repository'],
         long_help: 'The default editor will be opened for editing title and description.'
       ]
@@ -53,6 +54,7 @@ module Geet
         ['-l', '--label-patterns "legacy,code review"',     'Label patterns'],
         ['-m', '--milestone 1.5.0',                         'Milestone title pattern'],
         ['-r', '--reviewer-patterns john,tom,adrian,kevin', 'Reviewer login patterns'],
+        ['-s', '--summary title_and_description',           'Set the summary (title and optionally description'],
         ['-u', '--upstream',                                'Create on the upstream repository'],
         long_help: 'The default editor will be opened for editing title and description; if the PR adds one commit only, '\
                    'the content will be prepopulated with the commit description.'

--- a/lib/geet/commandline/editor.rb
+++ b/lib/geet/commandline/editor.rb
@@ -7,25 +7,24 @@ require_relative '../helpers/os_helper.rb'
 module Geet
   module Commandline
     class Editor
-      # Liberally ripp..., ahem, inspired from git.
-      SUMMARY_TEMPLATE = File.expand_path('../resources/templates/edit_summary.md', __dir__)
-      SUMMARY_TEMPLATE_SEPARATOR = '------------------------ >8 ------------------------'
-
       include Geet::Helpers::OsHelper
 
-      # Edits a summary in the default editor, providing the SUMMARY_TEMPLATE.
-      #
-      # A summary is a composition with a title and an optional description;
-      # if the description is not found, a blank string is returned.
-      #
-      # It's possible to append extra text to the help, by passing :extra_help.
-      #
-      def edit_summary(summary: nil, extra_help: nil)
-        full_summary = summary.to_s + IO.read(SUMMARY_TEMPLATE) + extra_help.to_s
+      # Git style!
+      HELP_SEPARATOR = '------------------------ >8 ------------------------'
 
-        raw_summary = edit_content_in_default_editor(full_summary)
+      # Edits a content in the default editor, optionally providing help.
+      #
+      # When the help is provided, it's appended to the bottom, separated by HELP_SEPARATOR.
+      # The help is stripped after the content if edited.
+      #
+      def edit_content(content: '', help: nil)
+        content += "\n\n" + HELP_SEPARATOR + "\n" + help if help
 
-        split_raw_summary(raw_summary)
+        edited_content = edit_content_in_default_editor(content)
+
+        edited_content = edited_content.split(HELP_SEPARATOR, 2).first if help
+
+        edited_content.strip
       end
 
       private
@@ -47,18 +46,6 @@ module Geet
         File.unlink(tempfile)
 
         content
-      end
-
-      def split_raw_summary(raw_summary)
-        raw_summary, _ = raw_summary.strip.split(SUMMARY_TEMPLATE_SEPARATOR, 2)
-
-        raise "Missing title!" if raw_summary.empty?
-
-        title, description = raw_summary.split(/\r|\n/, 2)
-
-        # The title may have a residual newline char; the description may not be present,
-        # or have multiple blank lines.
-        [title.strip, description.to_s.strip]
       end
 
       # HELPERS ##########################################################################

--- a/lib/geet/helpers/summary_helper.rb
+++ b/lib/geet/helpers/summary_helper.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Geet
+  module Helpers
+    module SummaryHelper
+      # Split the summary in title and description.
+      # The description is optional, but the title mandatory.
+      #
+      def split_summary(summary)
+        raise "Missing title in summary!" if summary.to_s.strip.empty?
+
+        title, description = summary.split(/\r|\n/, 2)
+
+        # The title may have a residual newline char; the description may not be present,
+        # or have multiple blank lines.
+        [title.strip, description.to_s.strip]
+      end
+    end
+  end
+end

--- a/lib/geet/resources/templates/edit_summary.md
+++ b/lib/geet/resources/templates/edit_summary.md
@@ -1,6 +1,3 @@
-
-
------------------------- >8 ------------------------
 Please enter above, the title and description for your changes.
 The first line is the title, and it's mandatory; lines between
 the second and the separator above, if present, are the description;


### PR DESCRIPTION
Very convenient when performing manual testing.

This PR also contains a refactoring of the Editor class, which is now a generic editor; the summary processing logic is now in a helper (SummaryHelper).

Closes #103.