### PR TITLE
Don't edit attributes on issue creation, when the user has no push access to a repository

### DIFF
--- a/bin/geet
+++ b/bin/geet
@@ -2,13 +2,13 @@
 # frozen_string_literal: true
 
 require 'simple_scripting/configuration'
-require_relative '../lib/geet/commandline/configuration.rb'
-require_relative '../lib/geet/commandline/commands.rb'
-require_relative '../lib/geet/commandline/editor.rb'
-require_relative '../lib/geet/git/repository.rb'
-require_relative '../lib/geet/helpers/summary_helper.rb'
-require_relative '../lib/geet/shared/constants.rb'
-require_relative '../lib/geet/utils/git_client.rb'
+require_relative '../lib/geet/commandline/configuration'
+require_relative '../lib/geet/commandline/commands'
+require_relative '../lib/geet/commandline/editor'
+require_relative '../lib/geet/git/repository'
+require_relative '../lib/geet/helpers/summary_helper'
+require_relative '../lib/geet/shared/constants'
+require_relative '../lib/geet/utils/git_client'
 Dir[File.join(__dir__, '../lib/geet/services/*.rb')].each { |filename| require filename }
 
 class GeetLauncher

--- a/bin/geet
+++ b/bin/geet
@@ -7,7 +7,7 @@ require_relative '../lib/geet/commandline/commands'
 require_relative '../lib/geet/commandline/editor'
 require_relative '../lib/geet/git/repository'
 require_relative '../lib/geet/helpers/summary_helper'
-require_relative '../lib/geet/shared/constants'
+require_relative '../lib/geet/shared/selection'
 require_relative '../lib/geet/utils/git_client'
 Dir[File.join(__dir__, '../lib/geet/services/*.rb')].each { |filename| require filename }
 
@@ -84,7 +84,7 @@ class GeetLauncher
 
   def default_to_manual_selection(options, *params)
     params.each do |param|
-      options[param] ||= Shared::Constants::MANUAL_LIST_SELECTION_FLAG
+      options[param] ||= Shared::Selection::MANUAL_LIST_SELECTION_FLAG
     end
 
     options

--- a/lib/geet/commandline/editor.rb
+++ b/lib/geet/commandline/editor.rb
@@ -2,7 +2,7 @@
 
 require 'tempfile'
 
-require_relative '../helpers/os_helper.rb'
+require_relative '../helpers/os_helper'
 
 module Geet
   module Commandline

--- a/lib/geet/github/api_interface.rb
+++ b/lib/geet/github/api_interface.rb
@@ -3,6 +3,7 @@
 require 'uri'
 require 'net/http'
 require 'json'
+require_relative '../shared/http_error'
 
 module Geet
   module Github
@@ -53,8 +54,8 @@ module Geet
           parsed_response = JSON.parse(response.body) if response.body
 
           if error?(response)
-            formatted_error = decode_and_format_error(parsed_response)
-            raise(formatted_error)
+            error_message = decode_and_format_error(parsed_response)
+            raise Geet::Shared::HttpError.new(error_message, response.code)
           end
 
           return parsed_response if !multipage

--- a/lib/geet/github/user.rb
+++ b/lib/geet/github/user.rb
@@ -1,12 +1,42 @@
 # frozen_string_literal: true
 
+require_relative '../shared/repo_permissions'
+require_relative '../shared/http_error'
+
 module Geet
   module Github
     class User
+      include Geet::Shared::RepoPermissions
+
       attr_reader :username
 
-      def initialize(username)
+      def initialize(username, api_interface)
         @username = username
+        @api_interface = api_interface
+      end
+
+      # See #repo_permission.
+      #
+      def has_permission?(permission)
+        user_permission = self.class.repo_permission(@api_interface)
+
+        permission_greater_or_equal_to?(user_permission, permission)
+      end
+
+      # See https://developer.github.com/v3/repos/collaborators/#check-if-a-user-is-a-collaborator
+      #
+      def is_collaborator?
+        api_path = "collaborators/#{@username}"
+
+        begin
+          @api_interface.send_request(api_path)
+
+          # 204: user is a collaborator.
+          true
+        rescue Geet::Shared::HttpError => error
+          # 404: not a collaborator.
+          error.code == 404 ? false : raise
+        end
       end
 
       # See https://developer.github.com/v3/users/#get-the-authenticated-user
@@ -16,7 +46,7 @@ module Geet
 
         response = api_interface.send_request(api_path)
 
-        new(response.fetch('login'))
+        new(response.fetch('login'), api_interface)
       end
 
       # Returns an array of User instances
@@ -25,7 +55,32 @@ module Geet
         api_path = 'collaborators'
         response = api_interface.send_request(api_path, multipage: true)
 
-        response.map { |user_entry| new(user_entry.fetch('login')) }
+        response.map { |user_entry| new(user_entry.fetch('login'), api_interface) }
+      end
+
+      # See https://developer.github.com/v3/repos/collaborators/#review-a-users-permission-level
+      #
+      def self.repo_permission(api_interface)
+        username = authenticated(api_interface).username
+        api_path = "collaborators/#{username}/permission"
+
+        response = api_interface.send_request(api_path)
+
+        permission = response.fetch('permission')
+
+        check_permission!(permission)
+
+        permission
+      end
+
+      class << self
+        private
+
+        # Future-proofing.
+        #
+        def check_permission!(permission)
+          raise "Unexpected permission #{permission.inspect}!" if !self::ALL_PERMISSIONS.include?(permission)
+        end
       end
     end
   end

--- a/lib/geet/services/create_gist.rb
+++ b/lib/geet/services/create_gist.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require_relative '../helpers/os_helper.rb'
-require_relative '../github/api_interface.rb'
-require_relative '../github/gist.rb'
+require_relative '../helpers/os_helper'
+require_relative '../github/api_interface'
+require_relative '../github/gist'
 
 module Geet
   module Services

--- a/lib/geet/services/list_milestones.rb
+++ b/lib/geet/services/list_milestones.rb
@@ -3,7 +3,7 @@
 module Geet
   module Services
     class ListMilestones
-      def initialize(repository, out: $output)
+      def initialize(repository, out: $stdout)
         @repository = repository
         @out = out
       end

--- a/lib/geet/shared/http_error.rb
+++ b/lib/geet/shared/http_error.rb
@@ -1,0 +1,13 @@
+module Geet
+  module Shared
+    class HttpError < RuntimeError
+      # Integer.
+      attr_reader :code
+
+      def initialize(message, code)
+        super(message)
+        @code = code.to_i
+      end
+    end
+  end
+end

--- a/lib/geet/shared/repo_permissions.rb
+++ b/lib/geet/shared/repo_permissions.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Geet
+  module Shared
+    module RepoPermissions
+      PERMISSION_ADMIN = 'admin'
+      PERMISSION_WRITE = 'write'
+      PERMISSION_READ = 'read'
+      PERMISSION_NONE = 'none'
+
+      ALL_PERMISSIONS = [
+        PERMISSION_ADMIN,
+        PERMISSION_WRITE,
+        PERMISSION_READ,
+        PERMISSION_NONE,
+      ]
+
+      # Not worth creating a Permission class at this stage.
+      #
+      def permission_greater_or_equal_to?(subject_permission, object_permission)
+        ALL_PERMISSIONS.index(subject_permission) <= ALL_PERMISSIONS.index(object_permission)
+      end
+    end
+  end
+end

--- a/lib/geet/shared/selection.rb
+++ b/lib/geet/shared/selection.rb
@@ -2,7 +2,7 @@
 
 module Geet
   module Shared
-    module Constants
+    module Selection
       MANUAL_LIST_SELECTION_FLAG = '-'.freeze
     end
   end

--- a/lib/geet/utils/attributes_selection_manager.rb
+++ b/lib/geet/utils/attributes_selection_manager.rb
@@ -2,7 +2,7 @@
 
 require_relative 'manual_list_selection'
 require_relative 'string_matching_selection'
-require_relative '../shared/constants'
+require_relative '../shared/selection'
 
 module Geet
   module Utils
@@ -14,7 +14,7 @@ module Geet
     # multiple attributes are required (typically, three).
     #
     class AttributesSelectionManager
-      include Geet::Shared::Constants
+      include Geet::Shared::Selection
 
       # Workaround for VCR not supporting multithreading; see https://github.com/vcr/vcr/issues/200.
       #

--- a/lib/geet/utils/git_client.rb
+++ b/lib/geet/utils/git_client.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'shellwords'
-require_relative '../helpers/os_helper.rb'
+require_relative '../helpers/os_helper'
 
 module Geet
   module Utils

--- a/spec/vcr_cassettes/create_issue.yml
+++ b/spec/vcr_cassettes/create_issue.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.github.com/repos/donaldduck/testrepo/labels
+    uri: https://api.github.com/user
     body:
       encoding: US-ASCII
       string: ''
@@ -25,7 +25,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Tue, 21 Nov 2017 13:01:10 GMT
+      - Mon, 05 Feb 2018 12:57:10 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -35,167 +35,17 @@ http_interactions:
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4993'
+      - '4910'
       X-Ratelimit-Reset:
-      - '1511270582'
+      - '1517838241'
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Vary:
       - Accept, Authorization, Cookie, X-GitHub-OTP
       Etag:
-      - W/"e6b0fca4f7e667cff0dc282de99f9b89"
-      X-Oauth-Scopes:
-      - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
-        delete_repo, gist, notifications, repo, user
-      X-Accepted-Oauth-Scopes:
-      - repo
-      X-Github-Media-Type:
-      - github.v3; format=json
-      Access-Control-Expose-Headers:
-      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
-        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
-      Access-Control-Allow-Origin:
-      - "*"
-      Content-Security-Policy:
-      - default-src 'none'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubdomains; preload
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - deny
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Runtime-Rack:
-      - '0.036300'
-      X-Github-Request-Id:
-      - EA5C:2B89:3D6EFD:9B6F1D:5A142395
-    body:
-      encoding: ASCII-8BIT
-      string: '[{"id":123456052,"url":"https://api.github.com/repos/donaldduck/testrepo/labels/bug","name":"bug","color":"ee0701","default":true},{"id":123456053,"url":"https://api.github.com/repos/donaldduck/testrepo/labels/duplicate","name":"duplicate","color":"cccccc","default":true},{"id":123456054,"url":"https://api.github.com/repos/donaldduck/testrepo/labels/enhancement","name":"enhancement","color":"84b6eb","default":true},{"id":123456056,"url":"https://api.github.com/repos/donaldduck/testrepo/labels/good%20first%20issue","name":"good
-        first issue","color":"7057ff","default":true},{"id":123456055,"url":"https://api.github.com/repos/donaldduck/testrepo/labels/help%20wanted","name":"help
-        wanted","color":"33aa3f","default":true},{"id":123456057,"url":"https://api.github.com/repos/donaldduck/testrepo/labels/invalid","name":"invalid","color":"e6e6e6","default":true},{"id":123456058,"url":"https://api.github.com/repos/donaldduck/testrepo/labels/question","name":"question","color":"cc317c","default":true},{"id":123456059,"url":"https://api.github.com/repos/donaldduck/testrepo/labels/wontfix","name":"wontfix","color":"ffffff","default":true}]'
-    http_version: 
-  recorded_at: Tue, 21 Nov 2017 13:01:10 GMT
-- request:
-    method: get
-    uri: https://api.github.com/repos/donaldduck/testrepo/milestones
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - application/vnd.github.v3+json
-      User-Agent:
-      - Ruby
-      Host:
-      - api.github.com
-      Authorization:
-      - Basic <GITHUB_CREDENTIALS>
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - GitHub.com
-      Date:
-      - Tue, 21 Nov 2017 13:01:10 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Status:
-      - 200 OK
-      X-Ratelimit-Limit:
-      - '5000'
-      X-Ratelimit-Remaining:
-      - '4992'
-      X-Ratelimit-Reset:
-      - '1511270582'
-      Cache-Control:
-      - private, max-age=60, s-maxage=60
-      Vary:
-      - Accept, Authorization, Cookie, X-GitHub-OTP
-      Etag:
-      - W/"4c0aca4795c0f10d50c8e9de02dd932b"
-      X-Oauth-Scopes:
-      - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
-        delete_repo, gist, notifications, repo, user
-      X-Accepted-Oauth-Scopes:
-      - repo
-      X-Github-Media-Type:
-      - github.v3; format=json
-      Access-Control-Expose-Headers:
-      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
-        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
-      Access-Control-Allow-Origin:
-      - "*"
-      Content-Security-Policy:
-      - default-src 'none'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubdomains; preload
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - deny
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Runtime-Rack:
-      - '0.043929'
-      X-Github-Request-Id:
-      - EA5E:2B89:3D6EFE:9B6F21:5A142395
-    body:
-      encoding: ASCII-8BIT
-      string: '[{"url":"https://api.github.com/repos/donaldduck/testrepo/milestones/1","html_url":"https://github.com/donaldduck/testrepo/milestone/1","labels_url":"https://api.github.com/repos/donaldduck/testrepo/milestones/1/labels","id":1234564,"number":1,"title":"0.0.1","description":"","creator":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"open_issues":0,"closed_issues":0,"state":"open","created_at":"2017-11-21T12:57:28Z","updated_at":"2017-11-21T12:57:28Z","due_on":null,"closed_at":null}]'
-    http_version: 
-  recorded_at: Tue, 21 Nov 2017 13:01:10 GMT
-- request:
-    method: get
-    uri: https://api.github.com/repos/donaldduck/testrepo/collaborators
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - application/vnd.github.v3+json
-      User-Agent:
-      - Ruby
-      Host:
-      - api.github.com
-      Authorization:
-      - Basic <GITHUB_CREDENTIALS>
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - GitHub.com
-      Date:
-      - Tue, 21 Nov 2017 13:01:10 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Status:
-      - 200 OK
-      X-Ratelimit-Limit:
-      - '5000'
-      X-Ratelimit-Remaining:
-      - '4991'
-      X-Ratelimit-Reset:
-      - '1511270582'
-      Cache-Control:
-      - private, max-age=60, s-maxage=60
-      Vary:
-      - Accept, Authorization, Cookie, X-GitHub-OTP
-      Etag:
-      - W/"6fcb0d23c8705eb29f61cfca042f7bd7"
+      - W/"894767eeeae043df2ab70d9ce0e1fa5b"
+      Last-Modified:
+      - Tue, 30 Jan 2018 20:56:34 GMT
       X-Oauth-Scopes:
       - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
         delete_repo, gist, notifications, repo, user
@@ -219,17 +69,543 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Runtime-Rack:
-      - '0.040870'
+      - '0.053681'
       X-Github-Request-Id:
-      - C482:2B89:3D6F00:9B6F24:5A142395
+      - C954:14EE:33F60FC:7DFEDE9:5A7854A6
     body:
       encoding: ASCII-8BIT
-      string: '[{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false,"permissions":{"admin":true,"push":true,"pull":true}},{"login":"donald-ts","id":12345692,"avatar_url":"https://avatars1.githubusercontent.com/u/33847392?v=4","gravatar_id":"","url":"https://api.github.com/users/donald-ts","html_url":"https://github.com/donald-ts","followers_url":"https://api.github.com/users/donald-ts/followers","following_url":"https://api.github.com/users/donald-ts/following{/other_user}","gists_url":"https://api.github.com/users/donald-ts/gists{/gist_id}","starred_url":"https://api.github.com/users/donald-ts/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donald-ts/subscriptions","organizations_url":"https://api.github.com/users/donald-ts/orgs","repos_url":"https://api.github.com/users/donald-ts/repos","events_url":"https://api.github.com/users/donald-ts/events{/privacy}","received_events_url":"https://api.github.com/users/donald-ts/received_events","type":"User","site_admin":false,"permissions":{"admin":false,"push":true,"pull":true}},{"login":"donald-fr","id":12345612,"avatar_url":"https://avatars2.githubusercontent.com/u/33847412?v=4","gravatar_id":"","url":"https://api.github.com/users/donald-fr","html_url":"https://github.com/donald-fr","followers_url":"https://api.github.com/users/donald-fr/followers","following_url":"https://api.github.com/users/donald-fr/following{/other_user}","gists_url":"https://api.github.com/users/donald-fr/gists{/gist_id}","starred_url":"https://api.github.com/users/donald-fr/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donald-fr/subscriptions","organizations_url":"https://api.github.com/users/donald-fr/orgs","repos_url":"https://api.github.com/users/donald-fr/repos","events_url":"https://api.github.com/users/donald-fr/events{/privacy}","received_events_url":"https://api.github.com/users/donald-fr/received_events","type":"User","site_admin":false,"permissions":{"admin":false,"push":true,"pull":true}}]'
+      string: '{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false,"name":"Donald
+        Duck","company":"@momcorp","blog":"","location":"Berlin","email":"donald.pub2@gmail.com","hireable":true,"bio":null,"public_repos":19,"public_gists":0,"followers":9,"following":0,"created_at":"2012-04-01T11:52:16Z","updated_at":"2018-01-30T20:56:34Z","private_gists":0,"total_private_repos":0,"owned_private_repos":0,"disk_usage":32591,"collaborators":0,"two_factor_authentication":true,"plan":{"name":"free","space":976562499,"collaborators":0,"private_repos":0}}'
     http_version: 
-  recorded_at: Tue, 21 Nov 2017 13:01:10 GMT
+  recorded_at: Mon, 05 Feb 2018 12:57:10 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/donaldduck/testrepo_f/collaborators/donaldduck
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Ruby
+      Host:
+      - api.github.com
+      Authorization:
+      - Basic <GITHUB_CREDENTIALS>
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Mon, 05 Feb 2018 12:57:11 GMT
+      Content-Type:
+      - application/octet-stream
+      Status:
+      - 204 No Content
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4909'
+      X-Ratelimit-Reset:
+      - '1517838241'
+      X-Oauth-Scopes:
+      - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
+        delete_repo, gist, notifications, repo, user
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - default-src 'none'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Runtime-Rack:
+      - '0.047014'
+      X-Github-Request-Id:
+      - 9398:14ED:3C4758B:7931C83:5A7854A6
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 05 Feb 2018 12:57:11 GMT
+- request:
+    method: get
+    uri: https://api.github.com/user
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Ruby
+      Host:
+      - api.github.com
+      Authorization:
+      - Basic <GITHUB_CREDENTIALS>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Mon, 05 Feb 2018 12:57:11 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4908'
+      X-Ratelimit-Reset:
+      - '1517838241'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      Etag:
+      - W/"894767eeeae043df2ab70d9ce0e1fa5b"
+      Last-Modified:
+      - Tue, 30 Jan 2018 20:56:34 GMT
+      X-Oauth-Scopes:
+      - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
+        delete_repo, gist, notifications, repo, user
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - default-src 'none'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Runtime-Rack:
+      - '0.043746'
+      X-Github-Request-Id:
+      - C958:14ED:3C475D6:7931D17:5A7854A7
+    body:
+      encoding: ASCII-8BIT
+      string: '{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false,"name":"Donald
+        Duck","company":"@momcorp","blog":"","location":"Berlin","email":"donald.pub2@gmail.com","hireable":true,"bio":null,"public_repos":19,"public_gists":0,"followers":9,"following":0,"created_at":"2012-04-01T11:52:16Z","updated_at":"2018-01-30T20:56:34Z","private_gists":0,"total_private_repos":0,"owned_private_repos":0,"disk_usage":32591,"collaborators":0,"two_factor_authentication":true,"plan":{"name":"free","space":976562499,"collaborators":0,"private_repos":0}}'
+    http_version: 
+  recorded_at: Mon, 05 Feb 2018 12:57:12 GMT
+- request:
+    method: get
+    uri: https://api.github.com/user
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Ruby
+      Host:
+      - api.github.com
+      Authorization:
+      - Basic <GITHUB_CREDENTIALS>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Mon, 05 Feb 2018 12:57:12 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4907'
+      X-Ratelimit-Reset:
+      - '1517838241'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      Etag:
+      - W/"894767eeeae043df2ab70d9ce0e1fa5b"
+      Last-Modified:
+      - Tue, 30 Jan 2018 20:56:34 GMT
+      X-Oauth-Scopes:
+      - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
+        delete_repo, gist, notifications, repo, user
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - default-src 'none'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Runtime-Rack:
+      - '0.047753'
+      X-Github-Request-Id:
+      - C95A:14EE:33F61AB:7DFEF84:5A7854A8
+    body:
+      encoding: ASCII-8BIT
+      string: '{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false,"name":"Donald
+        Duck","company":"@momcorp","blog":"","location":"Berlin","email":"donald.pub2@gmail.com","hireable":true,"bio":null,"public_repos":19,"public_gists":0,"followers":9,"following":0,"created_at":"2012-04-01T11:52:16Z","updated_at":"2018-01-30T20:56:34Z","private_gists":0,"total_private_repos":0,"owned_private_repos":0,"disk_usage":32591,"collaborators":0,"two_factor_authentication":true,"plan":{"name":"free","space":976562499,"collaborators":0,"private_repos":0}}'
+    http_version: 
+  recorded_at: Mon, 05 Feb 2018 12:57:12 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/donaldduck/testrepo_f/collaborators/donaldduck/permission
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Ruby
+      Host:
+      - api.github.com
+      Authorization:
+      - Basic <GITHUB_CREDENTIALS>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Mon, 05 Feb 2018 12:57:13 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4906'
+      X-Ratelimit-Reset:
+      - '1517838241'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      Etag:
+      - W/"2e0eb2906871bf26051feba70dcc7ce1"
+      X-Oauth-Scopes:
+      - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
+        delete_repo, gist, notifications, repo, user
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - default-src 'none'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Runtime-Rack:
+      - '0.034964'
+      X-Github-Request-Id:
+      - C95C:14EB:2308D95:4D2E40D:5A7854A8
+    body:
+      encoding: ASCII-8BIT
+      string: '{"permission":"admin","user":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false}}'
+    http_version: 
+  recorded_at: Mon, 05 Feb 2018 12:57:13 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/donaldduck/testrepo_f/labels
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Ruby
+      Host:
+      - api.github.com
+      Authorization:
+      - Basic <GITHUB_CREDENTIALS>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Mon, 05 Feb 2018 12:57:13 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4905'
+      X-Ratelimit-Reset:
+      - '1517838241'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      Etag:
+      - W/"4ba2555ba24479fbaef3c44c9f618b97"
+      X-Oauth-Scopes:
+      - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
+        delete_repo, gist, notifications, repo, user
+      X-Accepted-Oauth-Scopes:
+      - repo
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - default-src 'none'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Runtime-Rack:
+      - '0.040127'
+      X-Github-Request-Id:
+      - C95E:14EC:2CEA624:6010431:5A7854A9
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"id":123456797,"url":"https://api.github.com/repos/donaldduck/testrepo_f/labels/bug","name":"bug","color":"d73a4a","default":true},{"id":123456798,"url":"https://api.github.com/repos/donaldduck/testrepo_f/labels/duplicate","name":"duplicate","color":"cfd3d7","default":true},{"id":123456799,"url":"https://api.github.com/repos/donaldduck/testrepo_f/labels/enhancement","name":"enhancement","color":"a2eeef","default":true},{"id":123456801,"url":"https://api.github.com/repos/donaldduck/testrepo_f/labels/good%20first%20issue","name":"good
+        first issue","color":"7057ff","default":true},{"id":123456800,"url":"https://api.github.com/repos/donaldduck/testrepo_f/labels/help%20wanted","name":"help
+        wanted","color":"008672","default":true},{"id":123456802,"url":"https://api.github.com/repos/donaldduck/testrepo_f/labels/invalid","name":"invalid","color":"e4e669","default":true},{"id":123456803,"url":"https://api.github.com/repos/donaldduck/testrepo_f/labels/question","name":"question","color":"d876e3","default":true},{"id":123456804,"url":"https://api.github.com/repos/donaldduck/testrepo_f/labels/wontfix","name":"wontfix","color":"ffffff","default":true}]'
+    http_version: 
+  recorded_at: Mon, 05 Feb 2018 12:57:13 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/donaldduck/testrepo_f/milestones
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Ruby
+      Host:
+      - api.github.com
+      Authorization:
+      - Basic <GITHUB_CREDENTIALS>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Mon, 05 Feb 2018 12:57:14 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4904'
+      X-Ratelimit-Reset:
+      - '1517838241'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      Etag:
+      - W/"b6b89486e2ccd9f7ea58d3e6ba81bfba"
+      X-Oauth-Scopes:
+      - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
+        delete_repo, gist, notifications, repo, user
+      X-Accepted-Oauth-Scopes:
+      - repo
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - default-src 'none'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Runtime-Rack:
+      - '0.041211'
+      X-Github-Request-Id:
+      - 93A2:14ED:3C4772F:7931F6E:5A7854AA
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"url":"https://api.github.com/repos/donaldduck/testrepo_f/milestones/1","html_url":"https://github.com/donaldduck/testrepo_f/milestone/1","labels_url":"https://api.github.com/repos/donaldduck/testrepo_f/milestones/1/labels","id":1234568,"number":1,"title":"0.0.1","description":"","creator":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"open_issues":1,"closed_issues":0,"state":"open","created_at":"2018-02-05T12:44:37Z","updated_at":"2018-02-05T12:56:19Z","due_on":null,"closed_at":null}]'
+    http_version: 
+  recorded_at: Mon, 05 Feb 2018 12:57:14 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/donaldduck/testrepo_f/collaborators
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Ruby
+      Host:
+      - api.github.com
+      Authorization:
+      - Basic <GITHUB_CREDENTIALS>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Mon, 05 Feb 2018 12:57:15 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4903'
+      X-Ratelimit-Reset:
+      - '1517838241'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      Etag:
+      - W/"186587e673d8eca8c5812bdbca9881ed"
+      X-Oauth-Scopes:
+      - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
+        delete_repo, gist, notifications, repo, user
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - default-src 'none'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Runtime-Rack:
+      - '0.038298'
+      X-Github-Request-Id:
+      - C962:14EE:33F62B3:7DFF21C:5A7854AA
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false,"permissions":{"admin":true,"push":true,"pull":true}},{"login":"donald-fr","id":12345612,"avatar_url":"https://avatars2.githubusercontent.com/u/33847412?v=4","gravatar_id":"","url":"https://api.github.com/users/donald-fr","html_url":"https://github.com/donald-fr","followers_url":"https://api.github.com/users/donald-fr/followers","following_url":"https://api.github.com/users/donald-fr/following{/other_user}","gists_url":"https://api.github.com/users/donald-fr/gists{/gist_id}","starred_url":"https://api.github.com/users/donald-fr/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donald-fr/subscriptions","organizations_url":"https://api.github.com/users/donald-fr/orgs","repos_url":"https://api.github.com/users/donald-fr/repos","events_url":"https://api.github.com/users/donald-fr/events{/privacy}","received_events_url":"https://api.github.com/users/donald-fr/received_events","type":"User","site_admin":false,"permissions":{"admin":false,"push":true,"pull":true}}]'
+    http_version: 
+  recorded_at: Mon, 05 Feb 2018 12:57:15 GMT
 - request:
     method: post
-    uri: https://api.github.com/repos/donaldduck/testrepo/issues
+    uri: https://api.github.com/repos/donaldduck/testrepo_f/issues
     body:
       encoding: UTF-8
       string: '{"title":"Title","body":"Description","base":"master"}'
@@ -252,32 +628,32 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Tue, 21 Nov 2017 13:01:11 GMT
+      - Mon, 05 Feb 2018 12:57:15 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '1725'
+      - '1737'
       Status:
       - 201 Created
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4990'
+      - '4902'
       X-Ratelimit-Reset:
-      - '1511270582'
+      - '1517838241'
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Vary:
       - Accept, Authorization, Cookie, X-GitHub-OTP
       Etag:
-      - '"dd797c05a8ae748ced478110ed4b64cb"'
+      - '"3324f45bbb51c5675b7e7422fd571af3"'
       X-Oauth-Scopes:
       - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
         delete_repo, gist, notifications, repo, user
       X-Accepted-Oauth-Scopes:
       - ''
       Location:
-      - https://api.github.com/repos/donaldduck/testrepo/issues/1
+      - https://api.github.com/repos/donaldduck/testrepo_f/issues/2
       X-Github-Media-Type:
       - github.v3; format=json
       Access-Control-Expose-Headers:
@@ -296,17 +672,17 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Runtime-Rack:
-      - '0.168850'
+      - '0.155375'
       X-Github-Request-Id:
-      - C484:2B83:440AD1:8C8133:5A142396
+      - 93A6:14ED:3C477D1:79320BB:5A7854AB
     body:
       encoding: UTF-8
-      string: '{"url":"https://api.github.com/repos/donaldduck/testrepo/issues/1","repository_url":"https://api.github.com/repos/donaldduck/testrepo","labels_url":"https://api.github.com/repos/donaldduck/testrepo/issues/1/labels{/name}","comments_url":"https://api.github.com/repos/donaldduck/testrepo/issues/1/comments","events_url":"https://api.github.com/repos/donaldduck/testrepo/issues/1/events","html_url":"https://github.com/donaldduck/testrepo/issues/1","id":123456697,"number":1,"title":"Title","user":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"labels":[],"state":"open","locked":false,"assignee":null,"assignees":[],"milestone":null,"comments":0,"created_at":"2017-11-21T13:01:11Z","updated_at":"2017-11-21T13:01:11Z","closed_at":null,"author_association":"OWNER","body":"Description","closed_by":null}'
+      string: '{"url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/2","repository_url":"https://api.github.com/repos/donaldduck/testrepo_f","labels_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/2/labels{/name}","comments_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/2/comments","events_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/2/events","html_url":"https://github.com/donaldduck/testrepo_f/issues/2","id":123456762,"number":2,"title":"Title","user":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"labels":[],"state":"open","locked":false,"assignee":null,"assignees":[],"milestone":null,"comments":0,"created_at":"2018-02-05T12:57:15Z","updated_at":"2018-02-05T12:57:15Z","closed_at":null,"author_association":"OWNER","body":"Description","closed_by":null}'
     http_version: 
-  recorded_at: Tue, 21 Nov 2017 13:01:11 GMT
+  recorded_at: Mon, 05 Feb 2018 12:57:16 GMT
 - request:
     method: post
-    uri: https://api.github.com/repos/donaldduck/testrepo/issues/1/labels
+    uri: https://api.github.com/repos/donaldduck/testrepo_f/issues/2/labels
     body:
       encoding: UTF-8
       string: '["bug","invalid"]'
@@ -329,7 +705,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Tue, 21 Nov 2017 13:01:11 GMT
+      - Mon, 05 Feb 2018 12:57:16 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -339,15 +715,15 @@ http_interactions:
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4989'
+      - '4901'
       X-Ratelimit-Reset:
-      - '1511270582'
+      - '1517838241'
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Vary:
       - Accept, Authorization, Cookie, X-GitHub-OTP
       Etag:
-      - W/"d8530a9f6c6d8fcfd9a2625a81eb50e2"
+      - W/"475c63cc1229bf57fd5d8cdb02002527"
       X-Oauth-Scopes:
       - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
         delete_repo, gist, notifications, repo, user
@@ -371,17 +747,17 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Runtime-Rack:
-      - '0.122645'
+      - '0.084672'
       X-Github-Request-Id:
-      - C48A:2B83:440B23:8C81F8:5A142397
+      - 93A8:14EC:2CEA6E8:601061E:5A7854AC
     body:
       encoding: ASCII-8BIT
-      string: '[{"id":123456052,"url":"https://api.github.com/repos/donaldduck/testrepo/labels/bug","name":"bug","color":"ee0701","default":true},{"id":123456057,"url":"https://api.github.com/repos/donaldduck/testrepo/labels/invalid","name":"invalid","color":"e6e6e6","default":true}]'
+      string: '[{"id":123456797,"url":"https://api.github.com/repos/donaldduck/testrepo_f/labels/bug","name":"bug","color":"d73a4a","default":true},{"id":123456802,"url":"https://api.github.com/repos/donaldduck/testrepo_f/labels/invalid","name":"invalid","color":"e4e669","default":true}]'
     http_version: 
-  recorded_at: Tue, 21 Nov 2017 13:01:11 GMT
+  recorded_at: Mon, 05 Feb 2018 12:57:16 GMT
 - request:
     method: patch
-    uri: https://api.github.com/repos/donaldduck/testrepo/issues/1
+    uri: https://api.github.com/repos/donaldduck/testrepo_f/issues/2
     body:
       encoding: UTF-8
       string: '{"milestone":1}'
@@ -404,7 +780,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Tue, 21 Nov 2017 13:01:11 GMT
+      - Mon, 05 Feb 2018 12:57:16 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -414,15 +790,15 @@ http_interactions:
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4988'
+      - '4900'
       X-Ratelimit-Reset:
-      - '1511270582'
+      - '1517838241'
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Vary:
       - Accept, Authorization, Cookie, X-GitHub-OTP
       Etag:
-      - W/"ed9a6a430ec2e7f3fac9ac2b08700716"
+      - W/"16bbd7e876a7e84357c876d4da7bdc01"
       X-Oauth-Scopes:
       - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
         delete_repo, gist, notifications, repo, user
@@ -446,20 +822,20 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Runtime-Rack:
-      - '0.157004'
+      - '0.145271'
       X-Github-Request-Id:
-      - C488:2B89:3D6FDE:9B711E:5A142397
+      - C96A:14ED:3C4783E:7932173:5A7854AC
     body:
       encoding: ASCII-8BIT
-      string: '{"url":"https://api.github.com/repos/donaldduck/testrepo/issues/1","repository_url":"https://api.github.com/repos/donaldduck/testrepo","labels_url":"https://api.github.com/repos/donaldduck/testrepo/issues/1/labels{/name}","comments_url":"https://api.github.com/repos/donaldduck/testrepo/issues/1/comments","events_url":"https://api.github.com/repos/donaldduck/testrepo/issues/1/events","html_url":"https://github.com/donaldduck/testrepo/issues/1","id":123456697,"number":1,"title":"Title","user":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"labels":[{"id":123456052,"url":"https://api.github.com/repos/donaldduck/testrepo/labels/bug","name":"bug","color":"ee0701","default":true},{"id":123456057,"url":"https://api.github.com/repos/donaldduck/testrepo/labels/invalid","name":"invalid","color":"e6e6e6","default":true}],"state":"open","locked":false,"assignee":null,"assignees":[],"milestone":{"url":"https://api.github.com/repos/donaldduck/testrepo/milestones/1","html_url":"https://github.com/donaldduck/testrepo/milestone/1","labels_url":"https://api.github.com/repos/donaldduck/testrepo/milestones/1/labels","id":1234564,"number":1,"title":"0.0.1","description":"","creator":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"open_issues":1,"closed_issues":0,"state":"open","created_at":"2017-11-21T12:57:28Z","updated_at":"2017-11-21T13:01:11Z","due_on":null,"closed_at":null},"comments":0,"created_at":"2017-11-21T13:01:11Z","updated_at":"2017-11-21T13:01:11Z","closed_at":null,"author_association":"OWNER","body":"Description","closed_by":null}'
+      string: '{"url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/2","repository_url":"https://api.github.com/repos/donaldduck/testrepo_f","labels_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/2/labels{/name}","comments_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/2/comments","events_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/2/events","html_url":"https://github.com/donaldduck/testrepo_f/issues/2","id":123456762,"number":2,"title":"Title","user":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"labels":[{"id":123456797,"url":"https://api.github.com/repos/donaldduck/testrepo_f/labels/bug","name":"bug","color":"d73a4a","default":true},{"id":123456802,"url":"https://api.github.com/repos/donaldduck/testrepo_f/labels/invalid","name":"invalid","color":"e4e669","default":true}],"state":"open","locked":false,"assignee":null,"assignees":[],"milestone":{"url":"https://api.github.com/repos/donaldduck/testrepo_f/milestones/1","html_url":"https://github.com/donaldduck/testrepo_f/milestone/1","labels_url":"https://api.github.com/repos/donaldduck/testrepo_f/milestones/1/labels","id":1234568,"number":1,"title":"0.0.1","description":"","creator":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"open_issues":2,"closed_issues":0,"state":"open","created_at":"2018-02-05T12:44:37Z","updated_at":"2018-02-05T12:57:16Z","due_on":null,"closed_at":null},"comments":0,"created_at":"2018-02-05T12:57:15Z","updated_at":"2018-02-05T12:57:16Z","closed_at":null,"author_association":"OWNER","body":"Description","closed_by":null}'
     http_version: 
-  recorded_at: Tue, 21 Nov 2017 13:01:11 GMT
+  recorded_at: Mon, 05 Feb 2018 12:57:16 GMT
 - request:
     method: post
-    uri: https://api.github.com/repos/donaldduck/testrepo/issues/1/assignees
+    uri: https://api.github.com/repos/donaldduck/testrepo_f/issues/2/assignees
     body:
       encoding: UTF-8
-      string: '{"assignees":["donald-ts","donald-fr"]}'
+      string: '{"assignees":["donaldduck","donald-fr"]}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -479,32 +855,32 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Tue, 21 Nov 2017 13:01:12 GMT
+      - Mon, 05 Feb 2018 12:57:16 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '6069'
+      - '4739'
       Status:
       - 201 Created
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4987'
+      - '4899'
       X-Ratelimit-Reset:
-      - '1511270582'
+      - '1517838241'
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Vary:
       - Accept, Authorization, Cookie, X-GitHub-OTP
       Etag:
-      - '"3360dc185e2f32529bdf03f3621c4578"'
+      - '"78920dcfd5272852c6f9bd2639788bcc"'
       X-Oauth-Scopes:
       - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
         delete_repo, gist, notifications, repo, user
       X-Accepted-Oauth-Scopes:
       - ''
       Location:
-      - https://api.github.com/repos/donaldduck/testrepo/issues/1
+      - https://api.github.com/repos/donaldduck/testrepo_f/issues/2
       X-Github-Media-Type:
       - github.v3; format=json
       Access-Control-Expose-Headers:
@@ -523,12 +899,12 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Runtime-Rack:
-      - '0.239418'
+      - '0.215236'
       X-Github-Request-Id:
-      - C486:2B89:3D6FDE:9B711C:5A142397
+      - 93AA:14EE:33F633C:7DFF369:5A7854AC
     body:
       encoding: UTF-8
-      string: '{"url":"https://api.github.com/repos/donaldduck/testrepo/issues/1","repository_url":"https://api.github.com/repos/donaldduck/testrepo","labels_url":"https://api.github.com/repos/donaldduck/testrepo/issues/1/labels{/name}","comments_url":"https://api.github.com/repos/donaldduck/testrepo/issues/1/comments","events_url":"https://api.github.com/repos/donaldduck/testrepo/issues/1/events","html_url":"https://github.com/donaldduck/testrepo/issues/1","id":123456697,"number":1,"title":"Title","user":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"labels":[{"id":123456052,"url":"https://api.github.com/repos/donaldduck/testrepo/labels/bug","name":"bug","color":"ee0701","default":true},{"id":123456057,"url":"https://api.github.com/repos/donaldduck/testrepo/labels/invalid","name":"invalid","color":"e6e6e6","default":true}],"state":"open","locked":false,"assignee":{"login":"donald-fr","id":12345612,"avatar_url":"https://avatars2.githubusercontent.com/u/33847412?v=4","gravatar_id":"","url":"https://api.github.com/users/donald-fr","html_url":"https://github.com/donald-fr","followers_url":"https://api.github.com/users/donald-fr/followers","following_url":"https://api.github.com/users/donald-fr/following{/other_user}","gists_url":"https://api.github.com/users/donald-fr/gists{/gist_id}","starred_url":"https://api.github.com/users/donald-fr/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donald-fr/subscriptions","organizations_url":"https://api.github.com/users/donald-fr/orgs","repos_url":"https://api.github.com/users/donald-fr/repos","events_url":"https://api.github.com/users/donald-fr/events{/privacy}","received_events_url":"https://api.github.com/users/donald-fr/received_events","type":"User","site_admin":false},"assignees":[{"login":"donald-fr","id":12345612,"avatar_url":"https://avatars2.githubusercontent.com/u/33847412?v=4","gravatar_id":"","url":"https://api.github.com/users/donald-fr","html_url":"https://github.com/donald-fr","followers_url":"https://api.github.com/users/donald-fr/followers","following_url":"https://api.github.com/users/donald-fr/following{/other_user}","gists_url":"https://api.github.com/users/donald-fr/gists{/gist_id}","starred_url":"https://api.github.com/users/donald-fr/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donald-fr/subscriptions","organizations_url":"https://api.github.com/users/donald-fr/orgs","repos_url":"https://api.github.com/users/donald-fr/repos","events_url":"https://api.github.com/users/donald-fr/events{/privacy}","received_events_url":"https://api.github.com/users/donald-fr/received_events","type":"User","site_admin":false},{"login":"donald-ts","id":12345692,"avatar_url":"https://avatars1.githubusercontent.com/u/33847392?v=4","gravatar_id":"","url":"https://api.github.com/users/donald-ts","html_url":"https://github.com/donald-ts","followers_url":"https://api.github.com/users/donald-ts/followers","following_url":"https://api.github.com/users/donald-ts/following{/other_user}","gists_url":"https://api.github.com/users/donald-ts/gists{/gist_id}","starred_url":"https://api.github.com/users/donald-ts/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donald-ts/subscriptions","organizations_url":"https://api.github.com/users/donald-ts/orgs","repos_url":"https://api.github.com/users/donald-ts/repos","events_url":"https://api.github.com/users/donald-ts/events{/privacy}","received_events_url":"https://api.github.com/users/donald-ts/received_events","type":"User","site_admin":false}],"milestone":{"url":"https://api.github.com/repos/donaldduck/testrepo/milestones/1","html_url":"https://github.com/donaldduck/testrepo/milestone/1","labels_url":"https://api.github.com/repos/donaldduck/testrepo/milestones/1/labels","id":1234564,"number":1,"title":"0.0.1","description":"","creator":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"open_issues":1,"closed_issues":0,"state":"open","created_at":"2017-11-21T12:57:28Z","updated_at":"2017-11-21T13:01:11Z","due_on":null,"closed_at":null},"comments":0,"created_at":"2017-11-21T13:01:11Z","updated_at":"2017-11-21T13:01:11Z","closed_at":null,"author_association":"OWNER","body":"Description"}'
+      string: '{"url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/2","repository_url":"https://api.github.com/repos/donaldduck/testrepo_f","labels_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/2/labels{/name}","comments_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/2/comments","events_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/2/events","html_url":"https://github.com/donaldduck/testrepo_f/issues/2","id":123456762,"number":2,"title":"Title","user":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"labels":[{"id":123456797,"url":"https://api.github.com/repos/donaldduck/testrepo_f/labels/bug","name":"bug","color":"d73a4a","default":true},{"id":123456802,"url":"https://api.github.com/repos/donaldduck/testrepo_f/labels/invalid","name":"invalid","color":"e4e669","default":true}],"state":"open","locked":false,"assignee":{"login":"donald-fr","id":12345612,"avatar_url":"https://avatars2.githubusercontent.com/u/33847412?v=4","gravatar_id":"","url":"https://api.github.com/users/donald-fr","html_url":"https://github.com/donald-fr","followers_url":"https://api.github.com/users/donald-fr/followers","following_url":"https://api.github.com/users/donald-fr/following{/other_user}","gists_url":"https://api.github.com/users/donald-fr/gists{/gist_id}","starred_url":"https://api.github.com/users/donald-fr/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donald-fr/subscriptions","organizations_url":"https://api.github.com/users/donald-fr/orgs","repos_url":"https://api.github.com/users/donald-fr/repos","events_url":"https://api.github.com/users/donald-fr/events{/privacy}","received_events_url":"https://api.github.com/users/donald-fr/received_events","type":"User","site_admin":false},"assignees":[{"login":"donald-fr","id":12345612,"avatar_url":"https://avatars2.githubusercontent.com/u/33847412?v=4","gravatar_id":"","url":"https://api.github.com/users/donald-fr","html_url":"https://github.com/donald-fr","followers_url":"https://api.github.com/users/donald-fr/followers","following_url":"https://api.github.com/users/donald-fr/following{/other_user}","gists_url":"https://api.github.com/users/donald-fr/gists{/gist_id}","starred_url":"https://api.github.com/users/donald-fr/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donald-fr/subscriptions","organizations_url":"https://api.github.com/users/donald-fr/orgs","repos_url":"https://api.github.com/users/donald-fr/repos","events_url":"https://api.github.com/users/donald-fr/events{/privacy}","received_events_url":"https://api.github.com/users/donald-fr/received_events","type":"User","site_admin":false},{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false}],"milestone":null,"comments":0,"created_at":"2018-02-05T12:57:15Z","updated_at":"2018-02-05T12:57:16Z","closed_at":null,"author_association":"OWNER","body":"Description"}'
     http_version: 
-  recorded_at: Tue, 21 Nov 2017 13:01:12 GMT
+  recorded_at: Mon, 05 Feb 2018 12:57:16 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/create_issue_upstream.yml
+++ b/spec/vcr_cassettes/create_issue_upstream.yml
@@ -1,8 +1,155 @@
 ---
 http_interactions:
 - request:
+    method: get
+    uri: https://api.github.com/user
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Ruby
+      Host:
+      - api.github.com
+      Authorization:
+      - Basic <GITHUB_CREDENTIALS>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Mon, 05 Feb 2018 12:21:32 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4973'
+      X-Ratelimit-Reset:
+      - '1517834613'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      Etag:
+      - W/"9ed227278873ad9bdb804e3f45b1383e"
+      Last-Modified:
+      - Tue, 30 Jan 2018 20:56:34 GMT
+      X-Oauth-Scopes:
+      - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
+        delete_repo, gist, notifications, repo, user
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - default-src 'none'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Runtime-Rack:
+      - '0.076684'
+      X-Github-Request-Id:
+      - 8FE6:14EC:2CB9F3D:5FA8226:5A784C4B
+    body:
+      encoding: ASCII-8BIT
+      string: '{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false,"name":"Donald
+        Duck","company":"@momcorp","blog":"","location":"Berlin","email":"donald.pub2@gmail.com","hireable":true,"bio":null,"public_repos":18,"public_gists":0,"followers":9,"following":0,"created_at":"2012-04-01T11:52:16Z","updated_at":"2018-01-30T20:56:34Z","private_gists":0,"total_private_repos":0,"owned_private_repos":0,"disk_usage":32591,"collaborators":0,"two_factor_authentication":true,"plan":{"name":"free","space":976562499,"collaborators":0,"private_repos":0}}'
+    http_version: 
+  recorded_at: Mon, 05 Feb 2018 12:21:32 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/momcorp/therepo/collaborators/donaldduck
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Ruby
+      Host:
+      - api.github.com
+      Authorization:
+      - Basic <GITHUB_CREDENTIALS>
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Mon, 05 Feb 2018 12:21:33 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 404 Not Found
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4972'
+      X-Ratelimit-Reset:
+      - '1517834613'
+      X-Oauth-Scopes:
+      - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
+        delete_repo, gist, notifications, repo, user
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - default-src 'none'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Runtime-Rack:
+      - '0.030822'
+      X-Github-Request-Id:
+      - C5A6:14EC:2CB9F7A:5FA82A4:5A784C4C
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"Not Found","documentation_url":"https://developer.github.com/v3/repos/collaborators/#check-if-a-user-is-a-collaborator"}'
+    http_version: 
+  recorded_at: Mon, 05 Feb 2018 12:21:33 GMT
+- request:
     method: post
-    uri: https://api.github.com/repos/donald-fr/testrepo_u/issues
+    uri: https://api.github.com/repos/momcorp/therepo/issues
     body:
       encoding: UTF-8
       string: '{"title":"Title","body":"Description","base":"master"}'
@@ -25,32 +172,32 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Tue, 21 Nov 2017 13:01:25 GMT
+      - Mon, 05 Feb 2018 12:21:33 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '1720'
+      - '1864'
       Status:
       - 201 Created
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4986'
+      - '4971'
       X-Ratelimit-Reset:
-      - '1511270582'
+      - '1517834613'
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Vary:
       - Accept, Authorization, Cookie, X-GitHub-OTP
       Etag:
-      - '"4f22b9f19b5f2d56c87996ff9c1450c4"'
+      - '"cc0a9e95ca24d1d5ead805305ff4f450"'
       X-Oauth-Scopes:
       - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
         delete_repo, gist, notifications, repo, user
       X-Accepted-Oauth-Scopes:
       - ''
       Location:
-      - https://api.github.com/repos/donald-fr/testrepo_u/issues/7
+      - https://api.github.com/repos/momcorp/therepo/issues/42
       X-Github-Media-Type:
       - github.v3; format=json
       Access-Control-Expose-Headers:
@@ -69,12 +216,12 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Runtime-Rack:
-      - '0.194797'
+      - '0.162733'
       X-Github-Request-Id:
-      - C4A8:2B89:3D76FA:9B82AE:5A1423A4
+      - 8FEA:14ED:3C0B222:78B5001:5A784C4D
     body:
       encoding: UTF-8
-      string: '{"url":"https://api.github.com/repos/donald-fr/testrepo_u/issues/7","repository_url":"https://api.github.com/repos/donald-fr/testrepo_u","labels_url":"https://api.github.com/repos/donald-fr/testrepo_u/issues/7/labels{/name}","comments_url":"https://api.github.com/repos/donald-fr/testrepo_u/issues/7/comments","events_url":"https://api.github.com/repos/donald-fr/testrepo_u/issues/7/events","html_url":"https://github.com/donald-fr/testrepo_u/issues/7","id":123456767,"number":7,"title":"Title","user":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"labels":[],"state":"open","locked":false,"assignee":null,"assignees":[],"milestone":null,"comments":0,"created_at":"2017-11-21T13:01:25Z","updated_at":"2017-11-21T13:01:25Z","closed_at":null,"author_association":"COLLABORATOR","body":"Description","closed_by":null}'
+      string: '{"url":"https://api.github.com/repos/momcorp/therepo/issues/42","repository_url":"https://api.github.com/repos/momcorp/therepo","labels_url":"https://api.github.com/repos/momcorp/therepo/issues/42/labels{/name}","comments_url":"https://api.github.com/repos/momcorp/therepo/issues/42/comments","events_url":"https://api.github.com/repos/momcorp/therepo/issues/42/events","html_url":"https://github.com/momcorp/therepo/issues/42","id":123456144,"number":42,"title":"Title","user":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"labels":[],"state":"open","locked":false,"assignee":null,"assignees":[],"milestone":null,"comments":0,"created_at":"2018-02-05T12:21:33Z","updated_at":"2018-02-05T12:21:33Z","closed_at":null,"author_association":"COLLABORATOR","body":"Description","closed_by":null}'
     http_version: 
-  recorded_at: Tue, 21 Nov 2017 13:01:25 GMT
+  recorded_at: Mon, 05 Feb 2018 12:21:33 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
When a user has no push access to a repository, it's not possible to get the collaborators list, and it will raise an error, so permissions need to be checked.

When the permissions are not sufficient, the attributes are not searched/asked/set.

Address point 1 of #121.