### PR TITLE
Don't edit PR attributes on creation, if the user doesn't have repo write permissions

### DIFF
--- a/lib/geet/github/user.rb
+++ b/lib/geet/github/user.rb
@@ -35,7 +35,11 @@ module Geet
           true
         rescue Geet::Shared::HttpError => error
           # 404: not a collaborator.
-          error.code == 404 ? false : raise
+          # Although the documentation mentions only 404, 403 is a valid response as well; it seems
+          # that 404 is given on private repositories, while 403 on public ones ("Must have push
+          # access to view repository collaborators.").
+          #
+          (error.code == 404 || error.code == 403) ? false : raise
         end
       end
 

--- a/lib/geet/utils/git_client.rb
+++ b/lib/geet/utils/git_client.rb
@@ -153,7 +153,7 @@ module Geet
       private
 
       def gitdir_option
-        "--git-dir #{@location.shellescape}/.git" if @location
+        "-C #{@location.shellescape}" if @location
       end
     end
   end

--- a/spec/vcr_cassettes/create_pr.yml
+++ b/spec/vcr_cassettes/create_pr.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.github.com/repos/donaldduck/testrepo/collaborators
+    uri: https://api.github.com/user
     body:
       encoding: US-ASCII
       string: ''
@@ -25,7 +25,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Sun, 28 Jan 2018 20:19:32 GMT
+      - Mon, 05 Feb 2018 21:07:19 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -35,15 +35,17 @@ http_interactions:
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4774'
+      - '4994'
       X-Ratelimit-Reset:
-      - '1517170947'
+      - '1517867477'
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Vary:
       - Accept, Authorization, Cookie, X-GitHub-OTP
       Etag:
-      - W/"46dff1ccc47eba7864e9695443ac0ecd"
+      - W/"867a7455cae6fa03110405ae3f4f8ffe"
+      Last-Modified:
+      - Tue, 30 Jan 2018 20:56:34 GMT
       X-Oauth-Scopes:
       - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
         delete_repo, gist, notifications, repo, user
@@ -67,17 +69,18 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Runtime-Rack:
-      - '0.044911'
+      - '0.061856'
       X-Github-Request-Id:
-      - E6A6:1DED:2FB3B86:80D99C2:5A6E3053
+      - AF16:14EC:2F944A4:65DC5FB:5A78C787
     body:
       encoding: ASCII-8BIT
-      string: '[{"login":"mickeymouselaws-delivery","id":12345630,"avatar_url":"https://avatars0.githubusercontent.com/u/31344830?v=4","gravatar_id":"","url":"https://api.github.com/users/mickeymouselaws-delivery","html_url":"https://github.com/mickeymouselaws-delivery","followers_url":"https://api.github.com/users/mickeymouselaws-delivery/followers","following_url":"https://api.github.com/users/mickeymouselaws-delivery/following{/other_user}","gists_url":"https://api.github.com/users/mickeymouselaws-delivery/gists{/gist_id}","starred_url":"https://api.github.com/users/mickeymouselaws-delivery/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/mickeymouselaws-delivery/subscriptions","organizations_url":"https://api.github.com/users/mickeymouselaws-delivery/orgs","repos_url":"https://api.github.com/users/mickeymouselaws-delivery/repos","events_url":"https://api.github.com/users/mickeymouselaws-delivery/events{/privacy}","received_events_url":"https://api.github.com/users/mickeymouselaws-delivery/received_events","type":"User","site_admin":false,"permissions":{"admin":true,"push":true,"pull":true}},{"login":"donald-fr","id":12345612,"avatar_url":"https://avatars2.githubusercontent.com/u/33847412?v=4","gravatar_id":"","url":"https://api.github.com/users/donald-fr","html_url":"https://github.com/donald-fr","followers_url":"https://api.github.com/users/donald-fr/followers","following_url":"https://api.github.com/users/donald-fr/following{/other_user}","gists_url":"https://api.github.com/users/donald-fr/gists{/gist_id}","starred_url":"https://api.github.com/users/donald-fr/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donald-fr/subscriptions","organizations_url":"https://api.github.com/users/donald-fr/orgs","repos_url":"https://api.github.com/users/donald-fr/repos","events_url":"https://api.github.com/users/donald-fr/events{/privacy}","received_events_url":"https://api.github.com/users/donald-fr/received_events","type":"User","site_admin":false,"permissions":{"admin":false,"push":true,"pull":true}}]'
+      string: '{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false,"name":"Donald
+        Duck","company":"@momcorp","blog":"","location":"Berlin","email":"donald.pub2@gmail.com","hireable":true,"bio":null,"public_repos":19,"public_gists":0,"followers":9,"following":0,"created_at":"2012-04-01T11:52:16Z","updated_at":"2018-01-30T20:56:34Z","private_gists":0,"total_private_repos":0,"owned_private_repos":0,"disk_usage":32597,"collaborators":0,"two_factor_authentication":true,"plan":{"name":"free","space":976562499,"collaborators":0,"private_repos":0}}'
     http_version: 
-  recorded_at: Sun, 28 Jan 2018 20:19:32 GMT
+  recorded_at: Mon, 05 Feb 2018 21:07:19 GMT
 - request:
     method: get
-    uri: https://api.github.com/repos/donaldduck/testrepo/labels
+    uri: https://api.github.com/repos/donaldduck/testrepo_f/collaborators/donaldduck
     body:
       encoding: US-ASCII
       string: ''
@@ -94,36 +97,28 @@ http_interactions:
       - Basic <GITHUB_CREDENTIALS>
   response:
     status:
-      code: 200
-      message: OK
+      code: 204
+      message: No Content
     headers:
       Server:
       - GitHub.com
       Date:
-      - Sun, 28 Jan 2018 20:19:32 GMT
+      - Mon, 05 Feb 2018 21:07:20 GMT
       Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
+      - application/octet-stream
       Status:
-      - 200 OK
+      - 204 No Content
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4775'
+      - '4993'
       X-Ratelimit-Reset:
-      - '1517170947'
-      Cache-Control:
-      - private, max-age=60, s-maxage=60
-      Vary:
-      - Accept, Authorization, Cookie, X-GitHub-OTP
-      Etag:
-      - W/"49b8d4862b8431572943525e9de8b774"
+      - '1517867477'
       X-Oauth-Scopes:
       - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
         delete_repo, gist, notifications, repo, user
       X-Accepted-Oauth-Scopes:
-      - repo
+      - ''
       X-Github-Media-Type:
       - github.v3; format=json
       Access-Control-Expose-Headers:
@@ -142,93 +137,14 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Runtime-Rack:
-      - '0.036374'
+      - '0.034269'
       X-Github-Request-Id:
-      - 95F8:1DEA:2B9F096:59D8387:5A6E3053
+      - E4D6:14EB:2561777:524EECC:5A78C788
     body:
-      encoding: ASCII-8BIT
-      string: '[{"id":123456881,"url":"https://api.github.com/repos/donaldduck/testrepo/labels/bug","name":"bug","color":"ee0701","default":true},{"id":123456882,"url":"https://api.github.com/repos/donaldduck/testrepo/labels/duplicate","name":"duplicate","color":"cccccc","default":true},{"id":123456883,"url":"https://api.github.com/repos/donaldduck/testrepo/labels/enhancement","name":"enhancement","color":"84b6eb","default":true},{"id":123456886,"url":"https://api.github.com/repos/donaldduck/testrepo/labels/good%20first%20issue","name":"good
-        first issue","color":"7057ff","default":true},{"id":123456884,"url":"https://api.github.com/repos/donaldduck/testrepo/labels/help%20wanted","name":"help
-        wanted","color":"33aa3f","default":true},{"id":123456888,"url":"https://api.github.com/repos/donaldduck/testrepo/labels/invalid","name":"invalid","color":"e6e6e6","default":true},{"id":123456609,"url":"https://api.github.com/repos/donaldduck/testrepo/labels/pizza","name":"pizza","color":"d8dd12","default":false},{"id":123456890,"url":"https://api.github.com/repos/donaldduck/testrepo/labels/question","name":"question","color":"cc317c","default":true},{"id":123456892,"url":"https://api.github.com/repos/donaldduck/testrepo/labels/wontfix","name":"wontfix","color":"ffffff","default":true}]'
-    http_version: 
-  recorded_at: Sun, 28 Jan 2018 20:19:32 GMT
-- request:
-    method: get
-    uri: https://api.github.com/repos/donaldduck/testrepo/milestones
-    body:
-      encoding: US-ASCII
+      encoding: UTF-8
       string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - application/vnd.github.v3+json
-      User-Agent:
-      - Ruby
-      Host:
-      - api.github.com
-      Authorization:
-      - Basic <GITHUB_CREDENTIALS>
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - GitHub.com
-      Date:
-      - Sun, 28 Jan 2018 20:19:32 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Status:
-      - 200 OK
-      X-Ratelimit-Limit:
-      - '5000'
-      X-Ratelimit-Remaining:
-      - '4776'
-      X-Ratelimit-Reset:
-      - '1517170947'
-      Cache-Control:
-      - private, max-age=60, s-maxage=60
-      Vary:
-      - Accept, Authorization, Cookie, X-GitHub-OTP
-      Etag:
-      - W/"ecf7e32ee0b27ef02702235774f2adc4"
-      X-Oauth-Scopes:
-      - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
-        delete_repo, gist, notifications, repo, user
-      X-Accepted-Oauth-Scopes:
-      - repo
-      X-Github-Media-Type:
-      - github.v3; format=json
-      Access-Control-Expose-Headers:
-      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
-        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
-      Access-Control-Allow-Origin:
-      - "*"
-      Content-Security-Policy:
-      - default-src 'none'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubdomains; preload
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - deny
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Runtime-Rack:
-      - '0.037864'
-      X-Github-Request-Id:
-      - E6A2:1DEB:1BDF738:3CDFF27:5A6E3053
-    body:
-      encoding: ASCII-8BIT
-      string: '[{"url":"https://api.github.com/repos/donaldduck/testrepo/milestones/1","html_url":"https://github.com/donaldduck/testrepo/milestone/1","labels_url":"https://api.github.com/repos/donaldduck/testrepo/milestones/1/labels","id":1234567,"number":1,"title":"milestone
-        1","description":"","creator":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"open_issues":2,"closed_issues":6,"state":"open","created_at":"2018-01-17T22:32:15Z","updated_at":"2018-01-28T20:17:25Z","due_on":null,"closed_at":null},{"url":"https://api.github.com/repos/donaldduck/testrepo/milestones/2","html_url":"https://github.com/donaldduck/testrepo/milestone/2","labels_url":"https://api.github.com/repos/donaldduck/testrepo/milestones/2/labels","id":1234568,"number":2,"title":"milestone
-        2","description":"","creator":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"open_issues":0,"closed_issues":0,"state":"open","created_at":"2018-01-17T22:32:19Z","updated_at":"2018-01-17T22:32:19Z","due_on":null,"closed_at":null}]'
     http_version: 
-  recorded_at: Sun, 28 Jan 2018 20:19:32 GMT
+  recorded_at: Mon, 05 Feb 2018 21:07:20 GMT
 - request:
     method: get
     uri: https://api.github.com/user
@@ -254,7 +170,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Sun, 28 Jan 2018 20:19:33 GMT
+      - Mon, 05 Feb 2018 21:07:22 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -264,17 +180,17 @@ http_interactions:
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4773'
+      - '4992'
       X-Ratelimit-Reset:
-      - '1517170947'
+      - '1517867477'
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Vary:
       - Accept, Authorization, Cookie, X-GitHub-OTP
       Etag:
-      - W/"be46c707e70b25fe216b3536f27fe569"
+      - W/"867a7455cae6fa03110405ae3f4f8ffe"
       Last-Modified:
-      - Sun, 28 Jan 2018 20:03:28 GMT
+      - Tue, 30 Jan 2018 20:56:34 GMT
       X-Oauth-Scopes:
       - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
         delete_repo, gist, notifications, repo, user
@@ -298,18 +214,476 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Runtime-Rack:
-      - '0.047147'
+      - '0.046679'
       X-Github-Request-Id:
-      - E6A8:1DEA:2B9F0F3:59D8468:5A6E3055
+      - AF1A:14EC:2F945A0:65DC84A:5A78C78A
     body:
       encoding: ASCII-8BIT
       string: '{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false,"name":"Donald
-        Duck","company":"@mickeymouselaws","blog":"","location":"Berlin","email":"donald.pub2@gmail.com","hireable":true,"bio":null,"public_repos":16,"public_gists":0,"followers":9,"following":0,"created_at":"2012-04-01T11:52:16Z","updated_at":"2018-01-28T20:03:28Z","private_gists":0,"total_private_repos":1,"owned_private_repos":0,"disk_usage":32556,"collaborators":0,"two_factor_authentication":true,"plan":{"name":"free","space":976562499,"collaborators":0,"private_repos":0}}'
+        Duck","company":"@momcorp","blog":"","location":"Berlin","email":"donald.pub2@gmail.com","hireable":true,"bio":null,"public_repos":19,"public_gists":0,"followers":9,"following":0,"created_at":"2012-04-01T11:52:16Z","updated_at":"2018-01-30T20:56:34Z","private_gists":0,"total_private_repos":0,"owned_private_repos":0,"disk_usage":32597,"collaborators":0,"two_factor_authentication":true,"plan":{"name":"free","space":976562499,"collaborators":0,"private_repos":0}}'
     http_version: 
-  recorded_at: Sun, 28 Jan 2018 20:19:33 GMT
+  recorded_at: Mon, 05 Feb 2018 21:07:22 GMT
+- request:
+    method: get
+    uri: https://api.github.com/user
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Ruby
+      Host:
+      - api.github.com
+      Authorization:
+      - Basic <GITHUB_CREDENTIALS>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Mon, 05 Feb 2018 21:07:23 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4991'
+      X-Ratelimit-Reset:
+      - '1517867477'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      Etag:
+      - W/"867a7455cae6fa03110405ae3f4f8ffe"
+      Last-Modified:
+      - Tue, 30 Jan 2018 20:56:34 GMT
+      X-Oauth-Scopes:
+      - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
+        delete_repo, gist, notifications, repo, user
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - default-src 'none'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Runtime-Rack:
+      - '0.068534'
+      X-Github-Request-Id:
+      - AF1C:14ED:3F7E8D6:7FF8F37:5A78C78B
+    body:
+      encoding: ASCII-8BIT
+      string: '{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false,"name":"Donald
+        Duck","company":"@momcorp","blog":"","location":"Berlin","email":"donald.pub2@gmail.com","hireable":true,"bio":null,"public_repos":19,"public_gists":0,"followers":9,"following":0,"created_at":"2012-04-01T11:52:16Z","updated_at":"2018-01-30T20:56:34Z","private_gists":0,"total_private_repos":0,"owned_private_repos":0,"disk_usage":32597,"collaborators":0,"two_factor_authentication":true,"plan":{"name":"free","space":976562499,"collaborators":0,"private_repos":0}}'
+    http_version: 
+  recorded_at: Mon, 05 Feb 2018 21:07:24 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/donaldduck/testrepo_f/collaborators/donaldduck/permission
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Ruby
+      Host:
+      - api.github.com
+      Authorization:
+      - Basic <GITHUB_CREDENTIALS>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Mon, 05 Feb 2018 21:07:25 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4990'
+      X-Ratelimit-Reset:
+      - '1517867477'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      Etag:
+      - W/"2e0eb2906871bf26051feba70dcc7ce1"
+      X-Oauth-Scopes:
+      - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
+        delete_repo, gist, notifications, repo, user
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - default-src 'none'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Runtime-Rack:
+      - '0.052093'
+      X-Github-Request-Id:
+      - E4DC:14EB:256185D:524F121:5A78C78C
+    body:
+      encoding: ASCII-8BIT
+      string: '{"permission":"admin","user":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false}}'
+    http_version: 
+  recorded_at: Mon, 05 Feb 2018 21:07:25 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/donaldduck/testrepo_f/labels
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Ruby
+      Host:
+      - api.github.com
+      Authorization:
+      - Basic <GITHUB_CREDENTIALS>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Mon, 05 Feb 2018 21:07:26 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4989'
+      X-Ratelimit-Reset:
+      - '1517867477'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      Etag:
+      - W/"6b82345d2c890ae31294f18e1ed5b633"
+      X-Oauth-Scopes:
+      - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
+        delete_repo, gist, notifications, repo, user
+      X-Accepted-Oauth-Scopes:
+      - repo
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - default-src 'none'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Runtime-Rack:
+      - '0.031818'
+      X-Github-Request-Id:
+      - AF20:14EC:2F946A9:65DCACF:5A78C78D
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"id":123456108,"url":"https://api.github.com/repos/donaldduck/testrepo_f/labels/bug","name":"bug","color":"d73a4a","default":true},{"id":123456109,"url":"https://api.github.com/repos/donaldduck/testrepo_f/labels/duplicate","name":"duplicate","color":"cfd3d7","default":true},{"id":123456110,"url":"https://api.github.com/repos/donaldduck/testrepo_f/labels/enhancement","name":"enhancement","color":"a2eeef","default":true},{"id":123456112,"url":"https://api.github.com/repos/donaldduck/testrepo_f/labels/good%20first%20issue","name":"good
+        first issue","color":"7057ff","default":true},{"id":123456111,"url":"https://api.github.com/repos/donaldduck/testrepo_f/labels/help%20wanted","name":"help
+        wanted","color":"008672","default":true},{"id":123456113,"url":"https://api.github.com/repos/donaldduck/testrepo_f/labels/invalid","name":"invalid","color":"e4e669","default":true},{"id":123456114,"url":"https://api.github.com/repos/donaldduck/testrepo_f/labels/question","name":"question","color":"d876e3","default":true},{"id":123456115,"url":"https://api.github.com/repos/donaldduck/testrepo_f/labels/wontfix","name":"wontfix","color":"ffffff","default":true}]'
+    http_version: 
+  recorded_at: Mon, 05 Feb 2018 21:07:26 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/donaldduck/testrepo_f/milestones
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Ruby
+      Host:
+      - api.github.com
+      Authorization:
+      - Basic <GITHUB_CREDENTIALS>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Mon, 05 Feb 2018 21:07:27 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4988'
+      X-Ratelimit-Reset:
+      - '1517867477'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      Etag:
+      - W/"6f3877ab949fc49bca392bcaa9d26685"
+      X-Oauth-Scopes:
+      - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
+        delete_repo, gist, notifications, repo, user
+      X-Accepted-Oauth-Scopes:
+      - repo
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - default-src 'none'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Runtime-Rack:
+      - '0.045427'
+      X-Github-Request-Id:
+      - AF22:14EB:2561910:524F2B5:5A78C78E
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"url":"https://api.github.com/repos/donaldduck/testrepo_f/milestones/1","html_url":"https://github.com/donaldduck/testrepo_f/milestone/1","labels_url":"https://api.github.com/repos/donaldduck/testrepo_f/milestones/1/labels","id":1234564,"number":1,"title":"0.0.1","description":"","creator":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"open_issues":0,"closed_issues":0,"state":"open","created_at":"2018-02-05T21:05:13Z","updated_at":"2018-02-05T21:05:13Z","due_on":null,"closed_at":null}]'
+    http_version: 
+  recorded_at: Mon, 05 Feb 2018 21:07:27 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/donaldduck/testrepo_f/collaborators
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Ruby
+      Host:
+      - api.github.com
+      Authorization:
+      - Basic <GITHUB_CREDENTIALS>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Mon, 05 Feb 2018 21:07:28 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4987'
+      X-Ratelimit-Reset:
+      - '1517867477'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      Etag:
+      - W/"186587e673d8eca8c5812bdbca9881ed"
+      X-Oauth-Scopes:
+      - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
+        delete_repo, gist, notifications, repo, user
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - default-src 'none'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Runtime-Rack:
+      - '0.048457'
+      X-Github-Request-Id:
+      - E4E2:14EC:2F9478D:65DCC9D:5A78C790
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false,"permissions":{"admin":true,"push":true,"pull":true}},{"login":"donald-fr","id":12345612,"avatar_url":"https://avatars2.githubusercontent.com/u/33847412?v=4","gravatar_id":"","url":"https://api.github.com/users/donald-fr","html_url":"https://github.com/donald-fr","followers_url":"https://api.github.com/users/donald-fr/followers","following_url":"https://api.github.com/users/donald-fr/following{/other_user}","gists_url":"https://api.github.com/users/donald-fr/gists{/gist_id}","starred_url":"https://api.github.com/users/donald-fr/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donald-fr/subscriptions","organizations_url":"https://api.github.com/users/donald-fr/orgs","repos_url":"https://api.github.com/users/donald-fr/repos","events_url":"https://api.github.com/users/donald-fr/events{/privacy}","received_events_url":"https://api.github.com/users/donald-fr/received_events","type":"User","site_admin":false,"permissions":{"admin":false,"push":true,"pull":true}}]'
+    http_version: 
+  recorded_at: Mon, 05 Feb 2018 21:07:28 GMT
+- request:
+    method: get
+    uri: https://api.github.com/user
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Ruby
+      Host:
+      - api.github.com
+      Authorization:
+      - Basic <GITHUB_CREDENTIALS>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Mon, 05 Feb 2018 21:07:29 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4986'
+      X-Ratelimit-Reset:
+      - '1517867477'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      Etag:
+      - W/"867a7455cae6fa03110405ae3f4f8ffe"
+      Last-Modified:
+      - Tue, 30 Jan 2018 20:56:34 GMT
+      X-Oauth-Scopes:
+      - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
+        delete_repo, gist, notifications, repo, user
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - default-src 'none'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Runtime-Rack:
+      - '0.042361'
+      X-Github-Request-Id:
+      - E4E4:14ED:3F7EBB9:7FF94A9:5A78C791
+    body:
+      encoding: ASCII-8BIT
+      string: '{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false,"name":"Donald
+        Duck","company":"@momcorp","blog":"","location":"Berlin","email":"donald.pub2@gmail.com","hireable":true,"bio":null,"public_repos":19,"public_gists":0,"followers":9,"following":0,"created_at":"2012-04-01T11:52:16Z","updated_at":"2018-01-30T20:56:34Z","private_gists":0,"total_private_repos":0,"owned_private_repos":0,"disk_usage":32597,"collaborators":0,"two_factor_authentication":true,"plan":{"name":"free","space":976562499,"collaborators":0,"private_repos":0}}'
+    http_version: 
+  recorded_at: Mon, 05 Feb 2018 21:07:29 GMT
 - request:
     method: post
-    uri: https://api.github.com/repos/donaldduck/testrepo/pulls
+    uri: https://api.github.com/repos/donaldduck/testrepo_f/pulls
     body:
       encoding: UTF-8
       string: '{"title":"Title","body":"Description","head":"mybranch","base":"master"}'
@@ -332,32 +706,32 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Sun, 28 Jan 2018 20:19:35 GMT
+      - Mon, 05 Feb 2018 21:07:31 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '15134'
+      - '15314'
       Status:
       - 201 Created
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4772'
+      - '4985'
       X-Ratelimit-Reset:
-      - '1517170947'
+      - '1517867477'
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Vary:
       - Accept, Authorization, Cookie, X-GitHub-OTP
       Etag:
-      - '"50750e68a36c1f78c77068561d8cd649"'
+      - '"8f162619c852d862cb63fa453f165da2"'
       X-Oauth-Scopes:
       - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
         delete_repo, gist, notifications, repo, user
       X-Accepted-Oauth-Scopes:
       - ''
       Location:
-      - https://api.github.com/repos/donaldduck/testrepo/pulls/39
+      - https://api.github.com/repos/donaldduck/testrepo_f/pulls/1
       X-Github-Media-Type:
       - github.v3; format=json
       Access-Control-Expose-Headers:
@@ -376,14 +750,14 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Runtime-Rack:
-      - '0.310913'
+      - '0.385822'
       X-Github-Request-Id:
-      - E6AA:1DEC:4104604:79C97AC:5A6E3056
+      - AF28:14EC:2F94854:65DCE59:5A78C792
     body:
       encoding: UTF-8
-      string: '{"url":"https://api.github.com/repos/donaldduck/testrepo/pulls/39","id":123456150,"html_url":"https://github.com/donaldduck/testrepo/pull/39","diff_url":"https://github.com/donaldduck/testrepo/pull/39.diff","patch_url":"https://github.com/donaldduck/testrepo/pull/39.patch","issue_url":"https://api.github.com/repos/donaldduck/testrepo/issues/39","number":39,"state":"open","locked":false,"title":"Title","user":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"body":"Description","created_at":"2018-01-28T20:19:34Z","updated_at":"2018-01-28T20:19:34Z","closed_at":null,"merged_at":null,"merge_commit_sha":null,"assignee":null,"assignees":[],"requested_reviewers":[],"requested_teams":[],"milestone":null,"commits_url":"https://api.github.com/repos/donaldduck/testrepo/pulls/39/commits","review_comments_url":"https://api.github.com/repos/donaldduck/testrepo/pulls/39/comments","review_comment_url":"https://api.github.com/repos/donaldduck/testrepo/pulls/comments{/number}","comments_url":"https://api.github.com/repos/donaldduck/testrepo/issues/39/comments","statuses_url":"https://api.github.com/repos/donaldduck/testrepo/statuses/16aaf0dedd31dd7646dd1a9fa3cc1d911541bf49","head":{"label":"donaldduck:mybranch","ref":"mybranch","sha":"16aaf0dedd31dd7646dd1a9fa3cc1d911541bf49","user":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"repo":{"id":123456754,"name":"testrepo","full_name":"donaldduck/testrepo","owner":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"private":true,"html_url":"https://github.com/donaldduck/testrepo","description":null,"fork":true,"url":"https://api.github.com/repos/donaldduck/testrepo","forks_url":"https://api.github.com/repos/donaldduck/testrepo/forks","keys_url":"https://api.github.com/repos/donaldduck/testrepo/keys{/key_id}","collaborators_url":"https://api.github.com/repos/donaldduck/testrepo/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/donaldduck/testrepo/teams","hooks_url":"https://api.github.com/repos/donaldduck/testrepo/hooks","issue_events_url":"https://api.github.com/repos/donaldduck/testrepo/issues/events{/number}","events_url":"https://api.github.com/repos/donaldduck/testrepo/events","assignees_url":"https://api.github.com/repos/donaldduck/testrepo/assignees{/user}","branches_url":"https://api.github.com/repos/donaldduck/testrepo/branches{/branch}","tags_url":"https://api.github.com/repos/donaldduck/testrepo/tags","blobs_url":"https://api.github.com/repos/donaldduck/testrepo/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/donaldduck/testrepo/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/donaldduck/testrepo/git/refs{/sha}","trees_url":"https://api.github.com/repos/donaldduck/testrepo/git/trees{/sha}","statuses_url":"https://api.github.com/repos/donaldduck/testrepo/statuses/{sha}","languages_url":"https://api.github.com/repos/donaldduck/testrepo/languages","stargazers_url":"https://api.github.com/repos/donaldduck/testrepo/stargazers","contributors_url":"https://api.github.com/repos/donaldduck/testrepo/contributors","subscribers_url":"https://api.github.com/repos/donaldduck/testrepo/subscribers","subscription_url":"https://api.github.com/repos/donaldduck/testrepo/subscription","commits_url":"https://api.github.com/repos/donaldduck/testrepo/commits{/sha}","git_commits_url":"https://api.github.com/repos/donaldduck/testrepo/git/commits{/sha}","comments_url":"https://api.github.com/repos/donaldduck/testrepo/comments{/number}","issue_comment_url":"https://api.github.com/repos/donaldduck/testrepo/issues/comments{/number}","contents_url":"https://api.github.com/repos/donaldduck/testrepo/contents/{+path}","compare_url":"https://api.github.com/repos/donaldduck/testrepo/compare/{base}...{head}","merges_url":"https://api.github.com/repos/donaldduck/testrepo/merges","archive_url":"https://api.github.com/repos/donaldduck/testrepo/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/donaldduck/testrepo/downloads","issues_url":"https://api.github.com/repos/donaldduck/testrepo/issues{/number}","pulls_url":"https://api.github.com/repos/donaldduck/testrepo/pulls{/number}","milestones_url":"https://api.github.com/repos/donaldduck/testrepo/milestones{/number}","notifications_url":"https://api.github.com/repos/donaldduck/testrepo/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/donaldduck/testrepo/labels{/name}","releases_url":"https://api.github.com/repos/donaldduck/testrepo/releases{/id}","deployments_url":"https://api.github.com/repos/donaldduck/testrepo/deployments","created_at":"2017-12-23T18:58:57Z","updated_at":"2018-01-25T21:16:23Z","pushed_at":"2018-01-28T20:17:34Z","git_url":"git://github.com/donaldduck/testrepo.git","ssh_url":"git@github.com:donaldduck/testrepo.git","clone_url":"https://github.com/donaldduck/testrepo.git","svn_url":"https://github.com/donaldduck/testrepo","homepage":null,"size":15,"stargazers_count":0,"watchers_count":0,"language":"Ruby","has_issues":true,"has_projects":false,"has_downloads":true,"has_wiki":false,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"open_issues_count":13,"license":null,"forks":0,"open_issues":13,"watchers":0,"default_branch":"master"}},"base":{"label":"donaldduck:master","ref":"master","sha":"05e7bf92117c784e6d17194f1a07c8258bbc8d3a","user":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"repo":{"id":123456754,"name":"testrepo","full_name":"donaldduck/testrepo","owner":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"private":true,"html_url":"https://github.com/donaldduck/testrepo","description":null,"fork":true,"url":"https://api.github.com/repos/donaldduck/testrepo","forks_url":"https://api.github.com/repos/donaldduck/testrepo/forks","keys_url":"https://api.github.com/repos/donaldduck/testrepo/keys{/key_id}","collaborators_url":"https://api.github.com/repos/donaldduck/testrepo/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/donaldduck/testrepo/teams","hooks_url":"https://api.github.com/repos/donaldduck/testrepo/hooks","issue_events_url":"https://api.github.com/repos/donaldduck/testrepo/issues/events{/number}","events_url":"https://api.github.com/repos/donaldduck/testrepo/events","assignees_url":"https://api.github.com/repos/donaldduck/testrepo/assignees{/user}","branches_url":"https://api.github.com/repos/donaldduck/testrepo/branches{/branch}","tags_url":"https://api.github.com/repos/donaldduck/testrepo/tags","blobs_url":"https://api.github.com/repos/donaldduck/testrepo/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/donaldduck/testrepo/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/donaldduck/testrepo/git/refs{/sha}","trees_url":"https://api.github.com/repos/donaldduck/testrepo/git/trees{/sha}","statuses_url":"https://api.github.com/repos/donaldduck/testrepo/statuses/{sha}","languages_url":"https://api.github.com/repos/donaldduck/testrepo/languages","stargazers_url":"https://api.github.com/repos/donaldduck/testrepo/stargazers","contributors_url":"https://api.github.com/repos/donaldduck/testrepo/contributors","subscribers_url":"https://api.github.com/repos/donaldduck/testrepo/subscribers","subscription_url":"https://api.github.com/repos/donaldduck/testrepo/subscription","commits_url":"https://api.github.com/repos/donaldduck/testrepo/commits{/sha}","git_commits_url":"https://api.github.com/repos/donaldduck/testrepo/git/commits{/sha}","comments_url":"https://api.github.com/repos/donaldduck/testrepo/comments{/number}","issue_comment_url":"https://api.github.com/repos/donaldduck/testrepo/issues/comments{/number}","contents_url":"https://api.github.com/repos/donaldduck/testrepo/contents/{+path}","compare_url":"https://api.github.com/repos/donaldduck/testrepo/compare/{base}...{head}","merges_url":"https://api.github.com/repos/donaldduck/testrepo/merges","archive_url":"https://api.github.com/repos/donaldduck/testrepo/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/donaldduck/testrepo/downloads","issues_url":"https://api.github.com/repos/donaldduck/testrepo/issues{/number}","pulls_url":"https://api.github.com/repos/donaldduck/testrepo/pulls{/number}","milestones_url":"https://api.github.com/repos/donaldduck/testrepo/milestones{/number}","notifications_url":"https://api.github.com/repos/donaldduck/testrepo/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/donaldduck/testrepo/labels{/name}","releases_url":"https://api.github.com/repos/donaldduck/testrepo/releases{/id}","deployments_url":"https://api.github.com/repos/donaldduck/testrepo/deployments","created_at":"2017-12-23T18:58:57Z","updated_at":"2018-01-25T21:16:23Z","pushed_at":"2018-01-28T20:17:34Z","git_url":"git://github.com/donaldduck/testrepo.git","ssh_url":"git@github.com:donaldduck/testrepo.git","clone_url":"https://github.com/donaldduck/testrepo.git","svn_url":"https://github.com/donaldduck/testrepo","homepage":null,"size":15,"stargazers_count":0,"watchers_count":0,"language":"Ruby","has_issues":true,"has_projects":false,"has_downloads":true,"has_wiki":false,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"open_issues_count":13,"license":null,"forks":0,"open_issues":13,"watchers":0,"default_branch":"master"}},"_links":{"self":{"href":"https://api.github.com/repos/donaldduck/testrepo/pulls/39"},"html":{"href":"https://github.com/donaldduck/testrepo/pull/39"},"issue":{"href":"https://api.github.com/repos/donaldduck/testrepo/issues/39"},"comments":{"href":"https://api.github.com/repos/donaldduck/testrepo/issues/39/comments"},"review_comments":{"href":"https://api.github.com/repos/donaldduck/testrepo/pulls/39/comments"},"review_comment":{"href":"https://api.github.com/repos/donaldduck/testrepo/pulls/comments{/number}"},"commits":{"href":"https://api.github.com/repos/donaldduck/testrepo/pulls/39/commits"},"statuses":{"href":"https://api.github.com/repos/donaldduck/testrepo/statuses/16aaf0dedd31dd7646dd1a9fa3cc1d911541bf49"}},"author_association":"COLLABORATOR","merged":false,"mergeable":null,"rebaseable":null,"mergeable_state":"unknown","merged_by":null,"comments":0,"review_comments":0,"maintainer_can_modify":false,"commits":2,"additions":0,"deletions":0,"changed_files":2}'
+      string: '{"url":"https://api.github.com/repos/donaldduck/testrepo_f/pulls/1","id":123456698,"html_url":"https://github.com/donaldduck/testrepo_f/pull/1","diff_url":"https://github.com/donaldduck/testrepo_f/pull/1.diff","patch_url":"https://github.com/donaldduck/testrepo_f/pull/1.patch","issue_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/1","number":1,"state":"open","locked":false,"title":"Title","user":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"body":"Description","created_at":"2018-02-05T21:07:30Z","updated_at":"2018-02-05T21:07:30Z","closed_at":null,"merged_at":null,"merge_commit_sha":null,"assignee":null,"assignees":[],"requested_reviewers":[],"requested_teams":[],"milestone":null,"commits_url":"https://api.github.com/repos/donaldduck/testrepo_f/pulls/1/commits","review_comments_url":"https://api.github.com/repos/donaldduck/testrepo_f/pulls/1/comments","review_comment_url":"https://api.github.com/repos/donaldduck/testrepo_f/pulls/comments{/number}","comments_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/1/comments","statuses_url":"https://api.github.com/repos/donaldduck/testrepo_f/statuses/2ed302a6c2b3bbfab51c64321b20b854017b97ee","head":{"label":"donaldduck:mybranch","ref":"mybranch","sha":"2ed302a6c2b3bbfab51c64321b20b854017b97ee","user":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"repo":{"id":123456502,"name":"testrepo_f","full_name":"donaldduck/testrepo_f","owner":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"private":false,"html_url":"https://github.com/donaldduck/testrepo_f","description":null,"fork":true,"url":"https://api.github.com/repos/donaldduck/testrepo_f","forks_url":"https://api.github.com/repos/donaldduck/testrepo_f/forks","keys_url":"https://api.github.com/repos/donaldduck/testrepo_f/keys{/key_id}","collaborators_url":"https://api.github.com/repos/donaldduck/testrepo_f/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/donaldduck/testrepo_f/teams","hooks_url":"https://api.github.com/repos/donaldduck/testrepo_f/hooks","issue_events_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/events{/number}","events_url":"https://api.github.com/repos/donaldduck/testrepo_f/events","assignees_url":"https://api.github.com/repos/donaldduck/testrepo_f/assignees{/user}","branches_url":"https://api.github.com/repos/donaldduck/testrepo_f/branches{/branch}","tags_url":"https://api.github.com/repos/donaldduck/testrepo_f/tags","blobs_url":"https://api.github.com/repos/donaldduck/testrepo_f/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/donaldduck/testrepo_f/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/donaldduck/testrepo_f/git/refs{/sha}","trees_url":"https://api.github.com/repos/donaldduck/testrepo_f/git/trees{/sha}","statuses_url":"https://api.github.com/repos/donaldduck/testrepo_f/statuses/{sha}","languages_url":"https://api.github.com/repos/donaldduck/testrepo_f/languages","stargazers_url":"https://api.github.com/repos/donaldduck/testrepo_f/stargazers","contributors_url":"https://api.github.com/repos/donaldduck/testrepo_f/contributors","subscribers_url":"https://api.github.com/repos/donaldduck/testrepo_f/subscribers","subscription_url":"https://api.github.com/repos/donaldduck/testrepo_f/subscription","commits_url":"https://api.github.com/repos/donaldduck/testrepo_f/commits{/sha}","git_commits_url":"https://api.github.com/repos/donaldduck/testrepo_f/git/commits{/sha}","comments_url":"https://api.github.com/repos/donaldduck/testrepo_f/comments{/number}","issue_comment_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/comments{/number}","contents_url":"https://api.github.com/repos/donaldduck/testrepo_f/contents/{+path}","compare_url":"https://api.github.com/repos/donaldduck/testrepo_f/compare/{base}...{head}","merges_url":"https://api.github.com/repos/donaldduck/testrepo_f/merges","archive_url":"https://api.github.com/repos/donaldduck/testrepo_f/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/donaldduck/testrepo_f/downloads","issues_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues{/number}","pulls_url":"https://api.github.com/repos/donaldduck/testrepo_f/pulls{/number}","milestones_url":"https://api.github.com/repos/donaldduck/testrepo_f/milestones{/number}","notifications_url":"https://api.github.com/repos/donaldduck/testrepo_f/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/donaldduck/testrepo_f/labels{/name}","releases_url":"https://api.github.com/repos/donaldduck/testrepo_f/releases{/id}","deployments_url":"https://api.github.com/repos/donaldduck/testrepo_f/deployments","created_at":"2018-02-05T20:44:53Z","updated_at":"2018-02-05T21:04:59Z","pushed_at":"2018-02-05T21:03:24Z","git_url":"git://github.com/donaldduck/testrepo_f.git","ssh_url":"git@github.com:donaldduck/testrepo_f.git","clone_url":"https://github.com/donaldduck/testrepo_f.git","svn_url":"https://github.com/donaldduck/testrepo_f","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":false,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"open_issues_count":1,"license":null,"forks":0,"open_issues":1,"watchers":0,"default_branch":"master"}},"base":{"label":"donaldduck:master","ref":"master","sha":"c971bf0ec8076e78b866a41ba4c3a83bc6a4be73","user":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"repo":{"id":123456502,"name":"testrepo_f","full_name":"donaldduck/testrepo_f","owner":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"private":false,"html_url":"https://github.com/donaldduck/testrepo_f","description":null,"fork":true,"url":"https://api.github.com/repos/donaldduck/testrepo_f","forks_url":"https://api.github.com/repos/donaldduck/testrepo_f/forks","keys_url":"https://api.github.com/repos/donaldduck/testrepo_f/keys{/key_id}","collaborators_url":"https://api.github.com/repos/donaldduck/testrepo_f/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/donaldduck/testrepo_f/teams","hooks_url":"https://api.github.com/repos/donaldduck/testrepo_f/hooks","issue_events_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/events{/number}","events_url":"https://api.github.com/repos/donaldduck/testrepo_f/events","assignees_url":"https://api.github.com/repos/donaldduck/testrepo_f/assignees{/user}","branches_url":"https://api.github.com/repos/donaldduck/testrepo_f/branches{/branch}","tags_url":"https://api.github.com/repos/donaldduck/testrepo_f/tags","blobs_url":"https://api.github.com/repos/donaldduck/testrepo_f/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/donaldduck/testrepo_f/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/donaldduck/testrepo_f/git/refs{/sha}","trees_url":"https://api.github.com/repos/donaldduck/testrepo_f/git/trees{/sha}","statuses_url":"https://api.github.com/repos/donaldduck/testrepo_f/statuses/{sha}","languages_url":"https://api.github.com/repos/donaldduck/testrepo_f/languages","stargazers_url":"https://api.github.com/repos/donaldduck/testrepo_f/stargazers","contributors_url":"https://api.github.com/repos/donaldduck/testrepo_f/contributors","subscribers_url":"https://api.github.com/repos/donaldduck/testrepo_f/subscribers","subscription_url":"https://api.github.com/repos/donaldduck/testrepo_f/subscription","commits_url":"https://api.github.com/repos/donaldduck/testrepo_f/commits{/sha}","git_commits_url":"https://api.github.com/repos/donaldduck/testrepo_f/git/commits{/sha}","comments_url":"https://api.github.com/repos/donaldduck/testrepo_f/comments{/number}","issue_comment_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/comments{/number}","contents_url":"https://api.github.com/repos/donaldduck/testrepo_f/contents/{+path}","compare_url":"https://api.github.com/repos/donaldduck/testrepo_f/compare/{base}...{head}","merges_url":"https://api.github.com/repos/donaldduck/testrepo_f/merges","archive_url":"https://api.github.com/repos/donaldduck/testrepo_f/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/donaldduck/testrepo_f/downloads","issues_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues{/number}","pulls_url":"https://api.github.com/repos/donaldduck/testrepo_f/pulls{/number}","milestones_url":"https://api.github.com/repos/donaldduck/testrepo_f/milestones{/number}","notifications_url":"https://api.github.com/repos/donaldduck/testrepo_f/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/donaldduck/testrepo_f/labels{/name}","releases_url":"https://api.github.com/repos/donaldduck/testrepo_f/releases{/id}","deployments_url":"https://api.github.com/repos/donaldduck/testrepo_f/deployments","created_at":"2018-02-05T20:44:53Z","updated_at":"2018-02-05T21:04:59Z","pushed_at":"2018-02-05T21:03:24Z","git_url":"git://github.com/donaldduck/testrepo_f.git","ssh_url":"git@github.com:donaldduck/testrepo_f.git","clone_url":"https://github.com/donaldduck/testrepo_f.git","svn_url":"https://github.com/donaldduck/testrepo_f","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":false,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"open_issues_count":1,"license":null,"forks":0,"open_issues":1,"watchers":0,"default_branch":"master"}},"_links":{"self":{"href":"https://api.github.com/repos/donaldduck/testrepo_f/pulls/1"},"html":{"href":"https://github.com/donaldduck/testrepo_f/pull/1"},"issue":{"href":"https://api.github.com/repos/donaldduck/testrepo_f/issues/1"},"comments":{"href":"https://api.github.com/repos/donaldduck/testrepo_f/issues/1/comments"},"review_comments":{"href":"https://api.github.com/repos/donaldduck/testrepo_f/pulls/1/comments"},"review_comment":{"href":"https://api.github.com/repos/donaldduck/testrepo_f/pulls/comments{/number}"},"commits":{"href":"https://api.github.com/repos/donaldduck/testrepo_f/pulls/1/commits"},"statuses":{"href":"https://api.github.com/repos/donaldduck/testrepo_f/statuses/2ed302a6c2b3bbfab51c64321b20b854017b97ee"}},"author_association":"OWNER","merged":false,"mergeable":null,"rebaseable":null,"mergeable_state":"unknown","merged_by":null,"comments":0,"review_comments":0,"maintainer_can_modify":false,"commits":1,"additions":0,"deletions":0,"changed_files":1}'
     http_version: 
-  recorded_at: Sun, 28 Jan 2018 20:19:35 GMT
+  recorded_at: Mon, 05 Feb 2018 21:07:31 GMT
 - request:
     method: get
     uri: https://api.github.com/user
@@ -409,7 +783,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Sun, 28 Jan 2018 20:19:36 GMT
+      - Mon, 05 Feb 2018 21:07:32 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -419,17 +793,17 @@ http_interactions:
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4771'
+      - '4984'
       X-Ratelimit-Reset:
-      - '1517170947'
+      - '1517867477'
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Vary:
       - Accept, Authorization, Cookie, X-GitHub-OTP
       Etag:
-      - W/"be46c707e70b25fe216b3536f27fe569"
+      - W/"867a7455cae6fa03110405ae3f4f8ffe"
       Last-Modified:
-      - Sun, 28 Jan 2018 20:03:28 GMT
+      - Tue, 30 Jan 2018 20:56:34 GMT
       X-Oauth-Scopes:
       - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
         delete_repo, gist, notifications, repo, user
@@ -453,18 +827,18 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Runtime-Rack:
-      - '0.053456'
+      - '0.058912'
       X-Github-Request-Id:
-      - E6B2:1DED:2FB3CAD:80D9D78:5A6E3057
+      - E4EE:14ED:3F7ED20:7FF9756:5A78C793
     body:
       encoding: ASCII-8BIT
       string: '{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false,"name":"Donald
-        Duck","company":"@mickeymouselaws","blog":"","location":"Berlin","email":"donald.pub2@gmail.com","hireable":true,"bio":null,"public_repos":16,"public_gists":0,"followers":9,"following":0,"created_at":"2012-04-01T11:52:16Z","updated_at":"2018-01-28T20:03:28Z","private_gists":0,"total_private_repos":1,"owned_private_repos":0,"disk_usage":32556,"collaborators":0,"two_factor_authentication":true,"plan":{"name":"free","space":976562499,"collaborators":0,"private_repos":0}}'
+        Duck","company":"@momcorp","blog":"","location":"Berlin","email":"donald.pub2@gmail.com","hireable":true,"bio":null,"public_repos":19,"public_gists":0,"followers":9,"following":0,"created_at":"2012-04-01T11:52:16Z","updated_at":"2018-01-30T20:56:34Z","private_gists":0,"total_private_repos":0,"owned_private_repos":0,"disk_usage":32597,"collaborators":0,"two_factor_authentication":true,"plan":{"name":"free","space":976562499,"collaborators":0,"private_repos":0}}'
     http_version: 
-  recorded_at: Sun, 28 Jan 2018 20:19:36 GMT
+  recorded_at: Mon, 05 Feb 2018 21:07:32 GMT
 - request:
     method: post
-    uri: https://api.github.com/repos/donaldduck/testrepo/issues/39/labels
+    uri: https://api.github.com/repos/donaldduck/testrepo_f/issues/1/labels
     body:
       encoding: UTF-8
       string: '["bug","invalid"]'
@@ -487,7 +861,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Sun, 28 Jan 2018 20:19:36 GMT
+      - Mon, 05 Feb 2018 21:07:32 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -497,15 +871,15 @@ http_interactions:
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4770'
+      - '4983'
       X-Ratelimit-Reset:
-      - '1517170947'
+      - '1517867477'
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Vary:
       - Accept, Authorization, Cookie, X-GitHub-OTP
       Etag:
-      - W/"c75293cb7f605cb2006b08dfe1c5d409"
+      - W/"f60c8de2111043899cee7a6498ea73b6"
       X-Oauth-Scopes:
       - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
         delete_repo, gist, notifications, repo, user
@@ -529,17 +903,17 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Runtime-Rack:
-      - '0.124126'
+      - '0.187681'
       X-Github-Request-Id:
-      - E6AE:1DEA:2B9F189:59D85DC:5A6E3057
+      - E4E8:14ED:3F7ED20:7FF9755:5A78C793
     body:
       encoding: ASCII-8BIT
-      string: '[{"id":123456881,"url":"https://api.github.com/repos/donaldduck/testrepo/labels/bug","name":"bug","color":"ee0701","default":true},{"id":123456888,"url":"https://api.github.com/repos/donaldduck/testrepo/labels/invalid","name":"invalid","color":"e6e6e6","default":true}]'
+      string: '[{"id":123456108,"url":"https://api.github.com/repos/donaldduck/testrepo_f/labels/bug","name":"bug","color":"d73a4a","default":true},{"id":123456113,"url":"https://api.github.com/repos/donaldduck/testrepo_f/labels/invalid","name":"invalid","color":"e4e669","default":true}]'
     http_version: 
-  recorded_at: Sun, 28 Jan 2018 20:19:36 GMT
+  recorded_at: Mon, 05 Feb 2018 21:07:32 GMT
 - request:
     method: patch
-    uri: https://api.github.com/repos/donaldduck/testrepo/issues/39
+    uri: https://api.github.com/repos/donaldduck/testrepo_f/issues/1
     body:
       encoding: UTF-8
       string: '{"milestone":1}'
@@ -562,7 +936,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Sun, 28 Jan 2018 20:19:36 GMT
+      - Mon, 05 Feb 2018 21:07:32 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -572,15 +946,15 @@ http_interactions:
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4769'
+      - '4982'
       X-Ratelimit-Reset:
-      - '1517170947'
+      - '1517867477'
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Vary:
       - Accept, Authorization, Cookie, X-GitHub-OTP
       Etag:
-      - W/"06a081b028ab0165d4199bd2844135ac"
+      - W/"d3487435b6f4aba43871f6e3b240b320"
       X-Oauth-Scopes:
       - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
         delete_repo, gist, notifications, repo, user
@@ -604,18 +978,17 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Runtime-Rack:
-      - '0.158377'
+      - '0.317084'
       X-Github-Request-Id:
-      - 9600:1DEC:41046B5:79C98F1:5A6E3057
+      - AF2C:14EC:2F948D8:65DCF7A:5A78C793
     body:
       encoding: ASCII-8BIT
-      string: '{"url":"https://api.github.com/repos/donaldduck/testrepo/issues/39","repository_url":"https://api.github.com/repos/donaldduck/testrepo","labels_url":"https://api.github.com/repos/donaldduck/testrepo/issues/39/labels{/name}","comments_url":"https://api.github.com/repos/donaldduck/testrepo/issues/39/comments","events_url":"https://api.github.com/repos/donaldduck/testrepo/issues/39/events","html_url":"https://github.com/donaldduck/testrepo/pull/39","id":123456849,"number":39,"title":"Title","user":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"labels":[{"id":123456881,"url":"https://api.github.com/repos/donaldduck/testrepo/labels/bug","name":"bug","color":"ee0701","default":true},{"id":123456888,"url":"https://api.github.com/repos/donaldduck/testrepo/labels/invalid","name":"invalid","color":"e6e6e6","default":true}],"state":"open","locked":false,"assignee":null,"assignees":[],"milestone":{"url":"https://api.github.com/repos/donaldduck/testrepo/milestones/1","html_url":"https://github.com/donaldduck/testrepo/milestone/1","labels_url":"https://api.github.com/repos/donaldduck/testrepo/milestones/1/labels","id":1234567,"number":1,"title":"milestone
-        1","description":"","creator":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"open_issues":3,"closed_issues":6,"state":"open","created_at":"2018-01-17T22:32:15Z","updated_at":"2018-01-28T20:19:36Z","due_on":null,"closed_at":null},"comments":0,"created_at":"2018-01-28T20:19:34Z","updated_at":"2018-01-28T20:19:36Z","closed_at":null,"author_association":"COLLABORATOR","pull_request":{"url":"https://api.github.com/repos/donaldduck/testrepo/pulls/39","html_url":"https://github.com/donaldduck/testrepo/pull/39","diff_url":"https://github.com/donaldduck/testrepo/pull/39.diff","patch_url":"https://github.com/donaldduck/testrepo/pull/39.patch"},"body":"Description","closed_by":null}'
+      string: '{"url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/1","repository_url":"https://api.github.com/repos/donaldduck/testrepo_f","labels_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/1/labels{/name}","comments_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/1/comments","events_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/1/events","html_url":"https://github.com/donaldduck/testrepo_f/pull/1","id":123456412,"number":1,"title":"Title","user":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"labels":[{"id":123456108,"url":"https://api.github.com/repos/donaldduck/testrepo_f/labels/bug","name":"bug","color":"d73a4a","default":true},{"id":123456113,"url":"https://api.github.com/repos/donaldduck/testrepo_f/labels/invalid","name":"invalid","color":"e4e669","default":true}],"state":"open","locked":false,"assignee":null,"assignees":[],"milestone":{"url":"https://api.github.com/repos/donaldduck/testrepo_f/milestones/1","html_url":"https://github.com/donaldduck/testrepo_f/milestone/1","labels_url":"https://api.github.com/repos/donaldduck/testrepo_f/milestones/1/labels","id":1234564,"number":1,"title":"0.0.1","description":"","creator":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"open_issues":1,"closed_issues":0,"state":"open","created_at":"2018-02-05T21:05:13Z","updated_at":"2018-02-05T21:07:32Z","due_on":null,"closed_at":null},"comments":0,"created_at":"2018-02-05T21:07:30Z","updated_at":"2018-02-05T21:07:32Z","closed_at":null,"author_association":"OWNER","pull_request":{"url":"https://api.github.com/repos/donaldduck/testrepo_f/pulls/1","html_url":"https://github.com/donaldduck/testrepo_f/pull/1","diff_url":"https://github.com/donaldduck/testrepo_f/pull/1.diff","patch_url":"https://github.com/donaldduck/testrepo_f/pull/1.patch"},"body":"Description","closed_by":null}'
     http_version: 
-  recorded_at: Sun, 28 Jan 2018 20:19:36 GMT
+  recorded_at: Mon, 05 Feb 2018 21:07:32 GMT
 - request:
     method: post
-    uri: https://api.github.com/repos/donaldduck/testrepo/pulls/39/requested_reviewers
+    uri: https://api.github.com/repos/donaldduck/testrepo_f/pulls/1/requested_reviewers
     body:
       encoding: UTF-8
       string: '{"reviewers":["donald-fr"]}'
@@ -638,32 +1011,32 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Sun, 28 Jan 2018 20:19:36 GMT
+      - Mon, 05 Feb 2018 21:07:32 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '17253'
+      - '17433'
       Status:
       - 201 Created
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4768'
+      - '4981'
       X-Ratelimit-Reset:
-      - '1517170947'
+      - '1517867477'
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Vary:
       - Accept, Authorization, Cookie, X-GitHub-OTP
       Etag:
-      - '"d65e2be284ba4231f22b48e7191c15e2"'
+      - '"3e05a2c5de156f99bc4054f7948463eb"'
       X-Oauth-Scopes:
       - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
         delete_repo, gist, notifications, repo, user
       X-Accepted-Oauth-Scopes:
       - ''
       Location:
-      - https://api.github.com/repos/donaldduck/testrepo/pulls/39
+      - https://api.github.com/repos/donaldduck/testrepo_f/pulls/1
       X-Github-Media-Type:
       - github.v3; format=json
       Access-Control-Expose-Headers:
@@ -682,18 +1055,17 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Runtime-Rack:
-      - '0.212748'
+      - '0.474162'
       X-Github-Request-Id:
-      - E6B0:1DED:2FB3CAC:80D9D70:5A6E3057
+      - E4EC:14EE:371A550:8521958:5A78C793
     body:
       encoding: UTF-8
-      string: '{"url":"https://api.github.com/repos/donaldduck/testrepo/pulls/39","id":123456150,"html_url":"https://github.com/donaldduck/testrepo/pull/39","diff_url":"https://github.com/donaldduck/testrepo/pull/39.diff","patch_url":"https://github.com/donaldduck/testrepo/pull/39.patch","issue_url":"https://api.github.com/repos/donaldduck/testrepo/issues/39","number":39,"state":"open","locked":false,"title":"Title","user":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"body":"Description","created_at":"2018-01-28T20:19:34Z","updated_at":"2018-01-28T20:19:36Z","closed_at":null,"merged_at":null,"merge_commit_sha":"9fc66eb34176b6b4f23f36de08ce3a6a2264a4c2","assignee":null,"assignees":[],"requested_reviewers":[{"login":"donald-fr","id":12345612,"avatar_url":"https://avatars2.githubusercontent.com/u/33847412?v=4","gravatar_id":"","url":"https://api.github.com/users/donald-fr","html_url":"https://github.com/donald-fr","followers_url":"https://api.github.com/users/donald-fr/followers","following_url":"https://api.github.com/users/donald-fr/following{/other_user}","gists_url":"https://api.github.com/users/donald-fr/gists{/gist_id}","starred_url":"https://api.github.com/users/donald-fr/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donald-fr/subscriptions","organizations_url":"https://api.github.com/users/donald-fr/orgs","repos_url":"https://api.github.com/users/donald-fr/repos","events_url":"https://api.github.com/users/donald-fr/events{/privacy}","received_events_url":"https://api.github.com/users/donald-fr/received_events","type":"User","site_admin":false}],"requested_teams":[],"milestone":{"url":"https://api.github.com/repos/donaldduck/testrepo/milestones/1","html_url":"https://github.com/donaldduck/testrepo/milestone/1","labels_url":"https://api.github.com/repos/donaldduck/testrepo/milestones/1/labels","id":1234567,"number":1,"title":"milestone
-        1","description":"","creator":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"open_issues":3,"closed_issues":6,"state":"open","created_at":"2018-01-17T22:32:15Z","updated_at":"2018-01-28T20:19:36Z","due_on":null,"closed_at":null},"commits_url":"https://api.github.com/repos/donaldduck/testrepo/pulls/39/commits","review_comments_url":"https://api.github.com/repos/donaldduck/testrepo/pulls/39/comments","review_comment_url":"https://api.github.com/repos/donaldduck/testrepo/pulls/comments{/number}","comments_url":"https://api.github.com/repos/donaldduck/testrepo/issues/39/comments","statuses_url":"https://api.github.com/repos/donaldduck/testrepo/statuses/16aaf0dedd31dd7646dd1a9fa3cc1d911541bf49","head":{"label":"donaldduck:mybranch","ref":"mybranch","sha":"16aaf0dedd31dd7646dd1a9fa3cc1d911541bf49","user":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"repo":{"id":123456754,"name":"testrepo","full_name":"donaldduck/testrepo","owner":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"private":true,"html_url":"https://github.com/donaldduck/testrepo","description":null,"fork":true,"url":"https://api.github.com/repos/donaldduck/testrepo","forks_url":"https://api.github.com/repos/donaldduck/testrepo/forks","keys_url":"https://api.github.com/repos/donaldduck/testrepo/keys{/key_id}","collaborators_url":"https://api.github.com/repos/donaldduck/testrepo/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/donaldduck/testrepo/teams","hooks_url":"https://api.github.com/repos/donaldduck/testrepo/hooks","issue_events_url":"https://api.github.com/repos/donaldduck/testrepo/issues/events{/number}","events_url":"https://api.github.com/repos/donaldduck/testrepo/events","assignees_url":"https://api.github.com/repos/donaldduck/testrepo/assignees{/user}","branches_url":"https://api.github.com/repos/donaldduck/testrepo/branches{/branch}","tags_url":"https://api.github.com/repos/donaldduck/testrepo/tags","blobs_url":"https://api.github.com/repos/donaldduck/testrepo/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/donaldduck/testrepo/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/donaldduck/testrepo/git/refs{/sha}","trees_url":"https://api.github.com/repos/donaldduck/testrepo/git/trees{/sha}","statuses_url":"https://api.github.com/repos/donaldduck/testrepo/statuses/{sha}","languages_url":"https://api.github.com/repos/donaldduck/testrepo/languages","stargazers_url":"https://api.github.com/repos/donaldduck/testrepo/stargazers","contributors_url":"https://api.github.com/repos/donaldduck/testrepo/contributors","subscribers_url":"https://api.github.com/repos/donaldduck/testrepo/subscribers","subscription_url":"https://api.github.com/repos/donaldduck/testrepo/subscription","commits_url":"https://api.github.com/repos/donaldduck/testrepo/commits{/sha}","git_commits_url":"https://api.github.com/repos/donaldduck/testrepo/git/commits{/sha}","comments_url":"https://api.github.com/repos/donaldduck/testrepo/comments{/number}","issue_comment_url":"https://api.github.com/repos/donaldduck/testrepo/issues/comments{/number}","contents_url":"https://api.github.com/repos/donaldduck/testrepo/contents/{+path}","compare_url":"https://api.github.com/repos/donaldduck/testrepo/compare/{base}...{head}","merges_url":"https://api.github.com/repos/donaldduck/testrepo/merges","archive_url":"https://api.github.com/repos/donaldduck/testrepo/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/donaldduck/testrepo/downloads","issues_url":"https://api.github.com/repos/donaldduck/testrepo/issues{/number}","pulls_url":"https://api.github.com/repos/donaldduck/testrepo/pulls{/number}","milestones_url":"https://api.github.com/repos/donaldduck/testrepo/milestones{/number}","notifications_url":"https://api.github.com/repos/donaldduck/testrepo/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/donaldduck/testrepo/labels{/name}","releases_url":"https://api.github.com/repos/donaldduck/testrepo/releases{/id}","deployments_url":"https://api.github.com/repos/donaldduck/testrepo/deployments","created_at":"2017-12-23T18:58:57Z","updated_at":"2018-01-25T21:16:23Z","pushed_at":"2018-01-28T20:19:35Z","git_url":"git://github.com/donaldduck/testrepo.git","ssh_url":"git@github.com:donaldduck/testrepo.git","clone_url":"https://github.com/donaldduck/testrepo.git","svn_url":"https://github.com/donaldduck/testrepo","homepage":null,"size":15,"stargazers_count":0,"watchers_count":0,"language":"Ruby","has_issues":true,"has_projects":false,"has_downloads":true,"has_wiki":false,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"open_issues_count":13,"license":null,"forks":0,"open_issues":13,"watchers":0,"default_branch":"master"}},"base":{"label":"donaldduck:master","ref":"master","sha":"05e7bf92117c784e6d17194f1a07c8258bbc8d3a","user":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"repo":{"id":123456754,"name":"testrepo","full_name":"donaldduck/testrepo","owner":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"private":true,"html_url":"https://github.com/donaldduck/testrepo","description":null,"fork":true,"url":"https://api.github.com/repos/donaldduck/testrepo","forks_url":"https://api.github.com/repos/donaldduck/testrepo/forks","keys_url":"https://api.github.com/repos/donaldduck/testrepo/keys{/key_id}","collaborators_url":"https://api.github.com/repos/donaldduck/testrepo/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/donaldduck/testrepo/teams","hooks_url":"https://api.github.com/repos/donaldduck/testrepo/hooks","issue_events_url":"https://api.github.com/repos/donaldduck/testrepo/issues/events{/number}","events_url":"https://api.github.com/repos/donaldduck/testrepo/events","assignees_url":"https://api.github.com/repos/donaldduck/testrepo/assignees{/user}","branches_url":"https://api.github.com/repos/donaldduck/testrepo/branches{/branch}","tags_url":"https://api.github.com/repos/donaldduck/testrepo/tags","blobs_url":"https://api.github.com/repos/donaldduck/testrepo/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/donaldduck/testrepo/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/donaldduck/testrepo/git/refs{/sha}","trees_url":"https://api.github.com/repos/donaldduck/testrepo/git/trees{/sha}","statuses_url":"https://api.github.com/repos/donaldduck/testrepo/statuses/{sha}","languages_url":"https://api.github.com/repos/donaldduck/testrepo/languages","stargazers_url":"https://api.github.com/repos/donaldduck/testrepo/stargazers","contributors_url":"https://api.github.com/repos/donaldduck/testrepo/contributors","subscribers_url":"https://api.github.com/repos/donaldduck/testrepo/subscribers","subscription_url":"https://api.github.com/repos/donaldduck/testrepo/subscription","commits_url":"https://api.github.com/repos/donaldduck/testrepo/commits{/sha}","git_commits_url":"https://api.github.com/repos/donaldduck/testrepo/git/commits{/sha}","comments_url":"https://api.github.com/repos/donaldduck/testrepo/comments{/number}","issue_comment_url":"https://api.github.com/repos/donaldduck/testrepo/issues/comments{/number}","contents_url":"https://api.github.com/repos/donaldduck/testrepo/contents/{+path}","compare_url":"https://api.github.com/repos/donaldduck/testrepo/compare/{base}...{head}","merges_url":"https://api.github.com/repos/donaldduck/testrepo/merges","archive_url":"https://api.github.com/repos/donaldduck/testrepo/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/donaldduck/testrepo/downloads","issues_url":"https://api.github.com/repos/donaldduck/testrepo/issues{/number}","pulls_url":"https://api.github.com/repos/donaldduck/testrepo/pulls{/number}","milestones_url":"https://api.github.com/repos/donaldduck/testrepo/milestones{/number}","notifications_url":"https://api.github.com/repos/donaldduck/testrepo/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/donaldduck/testrepo/labels{/name}","releases_url":"https://api.github.com/repos/donaldduck/testrepo/releases{/id}","deployments_url":"https://api.github.com/repos/donaldduck/testrepo/deployments","created_at":"2017-12-23T18:58:57Z","updated_at":"2018-01-25T21:16:23Z","pushed_at":"2018-01-28T20:19:35Z","git_url":"git://github.com/donaldduck/testrepo.git","ssh_url":"git@github.com:donaldduck/testrepo.git","clone_url":"https://github.com/donaldduck/testrepo.git","svn_url":"https://github.com/donaldduck/testrepo","homepage":null,"size":15,"stargazers_count":0,"watchers_count":0,"language":"Ruby","has_issues":true,"has_projects":false,"has_downloads":true,"has_wiki":false,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"open_issues_count":13,"license":null,"forks":0,"open_issues":13,"watchers":0,"default_branch":"master"}},"_links":{"self":{"href":"https://api.github.com/repos/donaldduck/testrepo/pulls/39"},"html":{"href":"https://github.com/donaldduck/testrepo/pull/39"},"issue":{"href":"https://api.github.com/repos/donaldduck/testrepo/issues/39"},"comments":{"href":"https://api.github.com/repos/donaldduck/testrepo/issues/39/comments"},"review_comments":{"href":"https://api.github.com/repos/donaldduck/testrepo/pulls/39/comments"},"review_comment":{"href":"https://api.github.com/repos/donaldduck/testrepo/pulls/comments{/number}"},"commits":{"href":"https://api.github.com/repos/donaldduck/testrepo/pulls/39/commits"},"statuses":{"href":"https://api.github.com/repos/donaldduck/testrepo/statuses/16aaf0dedd31dd7646dd1a9fa3cc1d911541bf49"}},"author_association":"COLLABORATOR"}'
+      string: '{"url":"https://api.github.com/repos/donaldduck/testrepo_f/pulls/1","id":123456698,"html_url":"https://github.com/donaldduck/testrepo_f/pull/1","diff_url":"https://github.com/donaldduck/testrepo_f/pull/1.diff","patch_url":"https://github.com/donaldduck/testrepo_f/pull/1.patch","issue_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/1","number":1,"state":"open","locked":false,"title":"Title","user":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"body":"Description","created_at":"2018-02-05T21:07:30Z","updated_at":"2018-02-05T21:07:32Z","closed_at":null,"merged_at":null,"merge_commit_sha":"dd67417b22c513f9b54340fe5388124b78b86cae","assignee":null,"assignees":[],"requested_reviewers":[{"login":"donald-fr","id":12345612,"avatar_url":"https://avatars2.githubusercontent.com/u/33847412?v=4","gravatar_id":"","url":"https://api.github.com/users/donald-fr","html_url":"https://github.com/donald-fr","followers_url":"https://api.github.com/users/donald-fr/followers","following_url":"https://api.github.com/users/donald-fr/following{/other_user}","gists_url":"https://api.github.com/users/donald-fr/gists{/gist_id}","starred_url":"https://api.github.com/users/donald-fr/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donald-fr/subscriptions","organizations_url":"https://api.github.com/users/donald-fr/orgs","repos_url":"https://api.github.com/users/donald-fr/repos","events_url":"https://api.github.com/users/donald-fr/events{/privacy}","received_events_url":"https://api.github.com/users/donald-fr/received_events","type":"User","site_admin":false}],"requested_teams":[],"milestone":{"url":"https://api.github.com/repos/donaldduck/testrepo_f/milestones/1","html_url":"https://github.com/donaldduck/testrepo_f/milestone/1","labels_url":"https://api.github.com/repos/donaldduck/testrepo_f/milestones/1/labels","id":1234564,"number":1,"title":"0.0.1","description":"","creator":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"open_issues":1,"closed_issues":0,"state":"open","created_at":"2018-02-05T21:05:13Z","updated_at":"2018-02-05T21:07:32Z","due_on":null,"closed_at":null},"commits_url":"https://api.github.com/repos/donaldduck/testrepo_f/pulls/1/commits","review_comments_url":"https://api.github.com/repos/donaldduck/testrepo_f/pulls/1/comments","review_comment_url":"https://api.github.com/repos/donaldduck/testrepo_f/pulls/comments{/number}","comments_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/1/comments","statuses_url":"https://api.github.com/repos/donaldduck/testrepo_f/statuses/2ed302a6c2b3bbfab51c64321b20b854017b97ee","head":{"label":"donaldduck:mybranch","ref":"mybranch","sha":"2ed302a6c2b3bbfab51c64321b20b854017b97ee","user":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"repo":{"id":123456502,"name":"testrepo_f","full_name":"donaldduck/testrepo_f","owner":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"private":false,"html_url":"https://github.com/donaldduck/testrepo_f","description":null,"fork":true,"url":"https://api.github.com/repos/donaldduck/testrepo_f","forks_url":"https://api.github.com/repos/donaldduck/testrepo_f/forks","keys_url":"https://api.github.com/repos/donaldduck/testrepo_f/keys{/key_id}","collaborators_url":"https://api.github.com/repos/donaldduck/testrepo_f/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/donaldduck/testrepo_f/teams","hooks_url":"https://api.github.com/repos/donaldduck/testrepo_f/hooks","issue_events_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/events{/number}","events_url":"https://api.github.com/repos/donaldduck/testrepo_f/events","assignees_url":"https://api.github.com/repos/donaldduck/testrepo_f/assignees{/user}","branches_url":"https://api.github.com/repos/donaldduck/testrepo_f/branches{/branch}","tags_url":"https://api.github.com/repos/donaldduck/testrepo_f/tags","blobs_url":"https://api.github.com/repos/donaldduck/testrepo_f/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/donaldduck/testrepo_f/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/donaldduck/testrepo_f/git/refs{/sha}","trees_url":"https://api.github.com/repos/donaldduck/testrepo_f/git/trees{/sha}","statuses_url":"https://api.github.com/repos/donaldduck/testrepo_f/statuses/{sha}","languages_url":"https://api.github.com/repos/donaldduck/testrepo_f/languages","stargazers_url":"https://api.github.com/repos/donaldduck/testrepo_f/stargazers","contributors_url":"https://api.github.com/repos/donaldduck/testrepo_f/contributors","subscribers_url":"https://api.github.com/repos/donaldduck/testrepo_f/subscribers","subscription_url":"https://api.github.com/repos/donaldduck/testrepo_f/subscription","commits_url":"https://api.github.com/repos/donaldduck/testrepo_f/commits{/sha}","git_commits_url":"https://api.github.com/repos/donaldduck/testrepo_f/git/commits{/sha}","comments_url":"https://api.github.com/repos/donaldduck/testrepo_f/comments{/number}","issue_comment_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/comments{/number}","contents_url":"https://api.github.com/repos/donaldduck/testrepo_f/contents/{+path}","compare_url":"https://api.github.com/repos/donaldduck/testrepo_f/compare/{base}...{head}","merges_url":"https://api.github.com/repos/donaldduck/testrepo_f/merges","archive_url":"https://api.github.com/repos/donaldduck/testrepo_f/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/donaldduck/testrepo_f/downloads","issues_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues{/number}","pulls_url":"https://api.github.com/repos/donaldduck/testrepo_f/pulls{/number}","milestones_url":"https://api.github.com/repos/donaldduck/testrepo_f/milestones{/number}","notifications_url":"https://api.github.com/repos/donaldduck/testrepo_f/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/donaldduck/testrepo_f/labels{/name}","releases_url":"https://api.github.com/repos/donaldduck/testrepo_f/releases{/id}","deployments_url":"https://api.github.com/repos/donaldduck/testrepo_f/deployments","created_at":"2018-02-05T20:44:53Z","updated_at":"2018-02-05T21:04:59Z","pushed_at":"2018-02-05T21:07:31Z","git_url":"git://github.com/donaldduck/testrepo_f.git","ssh_url":"git@github.com:donaldduck/testrepo_f.git","clone_url":"https://github.com/donaldduck/testrepo_f.git","svn_url":"https://github.com/donaldduck/testrepo_f","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":false,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"open_issues_count":1,"license":null,"forks":0,"open_issues":1,"watchers":0,"default_branch":"master"}},"base":{"label":"donaldduck:master","ref":"master","sha":"c971bf0ec8076e78b866a41ba4c3a83bc6a4be73","user":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"repo":{"id":123456502,"name":"testrepo_f","full_name":"donaldduck/testrepo_f","owner":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"private":false,"html_url":"https://github.com/donaldduck/testrepo_f","description":null,"fork":true,"url":"https://api.github.com/repos/donaldduck/testrepo_f","forks_url":"https://api.github.com/repos/donaldduck/testrepo_f/forks","keys_url":"https://api.github.com/repos/donaldduck/testrepo_f/keys{/key_id}","collaborators_url":"https://api.github.com/repos/donaldduck/testrepo_f/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/donaldduck/testrepo_f/teams","hooks_url":"https://api.github.com/repos/donaldduck/testrepo_f/hooks","issue_events_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/events{/number}","events_url":"https://api.github.com/repos/donaldduck/testrepo_f/events","assignees_url":"https://api.github.com/repos/donaldduck/testrepo_f/assignees{/user}","branches_url":"https://api.github.com/repos/donaldduck/testrepo_f/branches{/branch}","tags_url":"https://api.github.com/repos/donaldduck/testrepo_f/tags","blobs_url":"https://api.github.com/repos/donaldduck/testrepo_f/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/donaldduck/testrepo_f/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/donaldduck/testrepo_f/git/refs{/sha}","trees_url":"https://api.github.com/repos/donaldduck/testrepo_f/git/trees{/sha}","statuses_url":"https://api.github.com/repos/donaldduck/testrepo_f/statuses/{sha}","languages_url":"https://api.github.com/repos/donaldduck/testrepo_f/languages","stargazers_url":"https://api.github.com/repos/donaldduck/testrepo_f/stargazers","contributors_url":"https://api.github.com/repos/donaldduck/testrepo_f/contributors","subscribers_url":"https://api.github.com/repos/donaldduck/testrepo_f/subscribers","subscription_url":"https://api.github.com/repos/donaldduck/testrepo_f/subscription","commits_url":"https://api.github.com/repos/donaldduck/testrepo_f/commits{/sha}","git_commits_url":"https://api.github.com/repos/donaldduck/testrepo_f/git/commits{/sha}","comments_url":"https://api.github.com/repos/donaldduck/testrepo_f/comments{/number}","issue_comment_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/comments{/number}","contents_url":"https://api.github.com/repos/donaldduck/testrepo_f/contents/{+path}","compare_url":"https://api.github.com/repos/donaldduck/testrepo_f/compare/{base}...{head}","merges_url":"https://api.github.com/repos/donaldduck/testrepo_f/merges","archive_url":"https://api.github.com/repos/donaldduck/testrepo_f/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/donaldduck/testrepo_f/downloads","issues_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues{/number}","pulls_url":"https://api.github.com/repos/donaldduck/testrepo_f/pulls{/number}","milestones_url":"https://api.github.com/repos/donaldduck/testrepo_f/milestones{/number}","notifications_url":"https://api.github.com/repos/donaldduck/testrepo_f/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/donaldduck/testrepo_f/labels{/name}","releases_url":"https://api.github.com/repos/donaldduck/testrepo_f/releases{/id}","deployments_url":"https://api.github.com/repos/donaldduck/testrepo_f/deployments","created_at":"2018-02-05T20:44:53Z","updated_at":"2018-02-05T21:04:59Z","pushed_at":"2018-02-05T21:07:31Z","git_url":"git://github.com/donaldduck/testrepo_f.git","ssh_url":"git@github.com:donaldduck/testrepo_f.git","clone_url":"https://github.com/donaldduck/testrepo_f.git","svn_url":"https://github.com/donaldduck/testrepo_f","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":false,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"open_issues_count":1,"license":null,"forks":0,"open_issues":1,"watchers":0,"default_branch":"master"}},"_links":{"self":{"href":"https://api.github.com/repos/donaldduck/testrepo_f/pulls/1"},"html":{"href":"https://github.com/donaldduck/testrepo_f/pull/1"},"issue":{"href":"https://api.github.com/repos/donaldduck/testrepo_f/issues/1"},"comments":{"href":"https://api.github.com/repos/donaldduck/testrepo_f/issues/1/comments"},"review_comments":{"href":"https://api.github.com/repos/donaldduck/testrepo_f/pulls/1/comments"},"review_comment":{"href":"https://api.github.com/repos/donaldduck/testrepo_f/pulls/comments{/number}"},"commits":{"href":"https://api.github.com/repos/donaldduck/testrepo_f/pulls/1/commits"},"statuses":{"href":"https://api.github.com/repos/donaldduck/testrepo_f/statuses/2ed302a6c2b3bbfab51c64321b20b854017b97ee"}},"author_association":"OWNER"}'
     http_version: 
-  recorded_at: Sun, 28 Jan 2018 20:19:36 GMT
+  recorded_at: Mon, 05 Feb 2018 21:07:33 GMT
 - request:
     method: post
-    uri: https://api.github.com/repos/donaldduck/testrepo/issues/39/assignees
+    uri: https://api.github.com/repos/donaldduck/testrepo_f/issues/1/assignees
     body:
       encoding: UTF-8
       string: '{"assignees":["donaldduck"]}'
@@ -716,32 +1088,32 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Sun, 28 Jan 2018 20:19:37 GMT
+      - Mon, 05 Feb 2018 21:07:33 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '5569'
+      - '5576'
       Status:
       - 201 Created
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4767'
+      - '4980'
       X-Ratelimit-Reset:
-      - '1517170947'
+      - '1517867477'
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Vary:
       - Accept, Authorization, Cookie, X-GitHub-OTP
       Etag:
-      - '"5dc97a8254ada25f1a69422894ec7d75"'
+      - '"d9adb5f6d008b34b5d6025e722b5a244"'
       X-Oauth-Scopes:
       - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
         delete_repo, gist, notifications, repo, user
       X-Accepted-Oauth-Scopes:
       - ''
       Location:
-      - https://api.github.com/repos/donaldduck/testrepo/issues/39
+      - https://api.github.com/repos/donaldduck/testrepo_f/issues/1
       X-Github-Media-Type:
       - github.v3; format=json
       Access-Control-Expose-Headers:
@@ -760,13 +1132,12 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Runtime-Rack:
-      - '0.166098'
+      - '0.236730'
       X-Github-Request-Id:
-      - 9608:1DED:2FB3CFF:80D9E65:5A6E3058
+      - E4F0:14EC:2F94955:65DD06A:5A78C794
     body:
       encoding: UTF-8
-      string: '{"url":"https://api.github.com/repos/donaldduck/testrepo/issues/39","repository_url":"https://api.github.com/repos/donaldduck/testrepo","labels_url":"https://api.github.com/repos/donaldduck/testrepo/issues/39/labels{/name}","comments_url":"https://api.github.com/repos/donaldduck/testrepo/issues/39/comments","events_url":"https://api.github.com/repos/donaldduck/testrepo/issues/39/events","html_url":"https://github.com/donaldduck/testrepo/pull/39","id":123456849,"number":39,"title":"Title","user":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"labels":[{"id":123456881,"url":"https://api.github.com/repos/donaldduck/testrepo/labels/bug","name":"bug","color":"ee0701","default":true},{"id":123456888,"url":"https://api.github.com/repos/donaldduck/testrepo/labels/invalid","name":"invalid","color":"e6e6e6","default":true}],"state":"open","locked":false,"assignee":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"assignees":[{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false}],"milestone":{"url":"https://api.github.com/repos/donaldduck/testrepo/milestones/1","html_url":"https://github.com/donaldduck/testrepo/milestone/1","labels_url":"https://api.github.com/repos/donaldduck/testrepo/milestones/1/labels","id":1234567,"number":1,"title":"milestone
-        1","description":"","creator":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"open_issues":3,"closed_issues":6,"state":"open","created_at":"2018-01-17T22:32:15Z","updated_at":"2018-01-28T20:19:36Z","due_on":null,"closed_at":null},"comments":0,"created_at":"2018-01-28T20:19:34Z","updated_at":"2018-01-28T20:19:37Z","closed_at":null,"author_association":"COLLABORATOR","pull_request":{"url":"https://api.github.com/repos/donaldduck/testrepo/pulls/39","html_url":"https://github.com/donaldduck/testrepo/pull/39","diff_url":"https://github.com/donaldduck/testrepo/pull/39.diff","patch_url":"https://github.com/donaldduck/testrepo/pull/39.patch"},"body":"Description"}'
+      string: '{"url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/1","repository_url":"https://api.github.com/repos/donaldduck/testrepo_f","labels_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/1/labels{/name}","comments_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/1/comments","events_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/1/events","html_url":"https://github.com/donaldduck/testrepo_f/pull/1","id":123456412,"number":1,"title":"Title","user":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"labels":[{"id":123456108,"url":"https://api.github.com/repos/donaldduck/testrepo_f/labels/bug","name":"bug","color":"d73a4a","default":true},{"id":123456113,"url":"https://api.github.com/repos/donaldduck/testrepo_f/labels/invalid","name":"invalid","color":"e4e669","default":true}],"state":"open","locked":false,"assignee":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"assignees":[{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false}],"milestone":{"url":"https://api.github.com/repos/donaldduck/testrepo_f/milestones/1","html_url":"https://github.com/donaldduck/testrepo_f/milestone/1","labels_url":"https://api.github.com/repos/donaldduck/testrepo_f/milestones/1/labels","id":1234564,"number":1,"title":"0.0.1","description":"","creator":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"open_issues":1,"closed_issues":0,"state":"open","created_at":"2018-02-05T21:05:13Z","updated_at":"2018-02-05T21:07:32Z","due_on":null,"closed_at":null},"comments":0,"created_at":"2018-02-05T21:07:30Z","updated_at":"2018-02-05T21:07:33Z","closed_at":null,"author_association":"OWNER","pull_request":{"url":"https://api.github.com/repos/donaldduck/testrepo_f/pulls/1","html_url":"https://github.com/donaldduck/testrepo_f/pull/1","diff_url":"https://github.com/donaldduck/testrepo_f/pull/1.diff","patch_url":"https://github.com/donaldduck/testrepo_f/pull/1.patch"},"body":"Description"}'
     http_version: 
-  recorded_at: Sun, 28 Jan 2018 20:19:37 GMT
+  recorded_at: Mon, 05 Feb 2018 21:07:33 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/create_pr_in_auto_mode_create_upstream.yml
+++ b/spec/vcr_cassettes/create_pr_in_auto_mode_create_upstream.yml
@@ -1,11 +1,11 @@
 ---
 http_interactions:
 - request:
-    method: post
-    uri: https://api.github.com/repos/donaldduck/testrepo/pulls
+    method: get
+    uri: https://api.github.com/user
     body:
-      encoding: UTF-8
-      string: '{"title":"Title","body":"Description","head":"mybranch","base":"master"}'
+      encoding: US-ASCII
+      string: ''
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -19,38 +19,38 @@ http_interactions:
       - Basic <GITHUB_CREDENTIALS>
   response:
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
     headers:
       Server:
       - GitHub.com
       Date:
-      - Thu, 25 Jan 2018 21:18:53 GMT
+      - Mon, 05 Feb 2018 21:32:49 GMT
       Content-Type:
       - application/json; charset=utf-8
-      Content-Length:
-      - '15130'
+      Transfer-Encoding:
+      - chunked
       Status:
-      - 201 Created
+      - 200 OK
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4999'
+      - '4944'
       X-Ratelimit-Reset:
-      - '1516918733'
+      - '1517867477'
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Vary:
       - Accept, Authorization, Cookie, X-GitHub-OTP
       Etag:
-      - '"ffffffff506017e2d69fb3afa0f369a8"'
+      - W/"867a7455cae6fa03110405ae3f4f8ffe"
+      Last-Modified:
+      - Tue, 30 Jan 2018 20:56:34 GMT
       X-Oauth-Scopes:
       - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
         delete_repo, gist, notifications, repo, user
       X-Accepted-Oauth-Scopes:
       - ''
-      Location:
-      - https://api.github.com/repos/donaldduck/testrepo/pulls/30
       X-Github-Media-Type:
       - github.v3; format=json
       Access-Control-Expose-Headers:
@@ -69,14 +69,82 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Runtime-Rack:
-      - '0.322337'
+      - '0.047031'
       X-Github-Request-Id:
-      - C644:1DEB:F9ADFC:2FFFFFFF5A6A49BC
+      - E644:14EE:37420DF:857BF75:5A78CD80
+    body:
+      encoding: ASCII-8BIT
+      string: '{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false,"name":"Donald
+        Duck","company":"@momcorp","blog":"","location":"Berlin","email":"donald.pub2@gmail.com","hireable":true,"bio":null,"public_repos":19,"public_gists":0,"followers":9,"following":0,"created_at":"2012-04-01T11:52:16Z","updated_at":"2018-01-30T20:56:34Z","private_gists":0,"total_private_repos":0,"owned_private_repos":0,"disk_usage":32597,"collaborators":0,"two_factor_authentication":true,"plan":{"name":"free","space":976562499,"collaborators":0,"private_repos":0}}'
+    http_version: 
+  recorded_at: Mon, 05 Feb 2018 21:32:49 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/donaldduck/testrepo_f/collaborators/donaldduck
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Ruby
+      Host:
+      - api.github.com
+      Authorization:
+      - Basic <GITHUB_CREDENTIALS>
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Mon, 05 Feb 2018 21:32:50 GMT
+      Content-Type:
+      - application/octet-stream
+      Status:
+      - 204 No Content
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4943'
+      X-Ratelimit-Reset:
+      - '1517867477'
+      X-Oauth-Scopes:
+      - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
+        delete_repo, gist, notifications, repo, user
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - default-src 'none'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Runtime-Rack:
+      - '0.029048'
+      X-Github-Request-Id:
+      - B08A:14EC:2FB72A3:6626D9E:5A78CD81
     body:
       encoding: UTF-8
-      string: '{"url":"https://api.github.com/repos/donaldduck/testrepo/pulls/30","id":123456858,"html_url":"https://github.com/donaldduck/testrepo/pull/30","diff_url":"https://github.com/donaldduck/testrepo/pull/30.diff","patch_url":"https://github.com/donaldduck/testrepo/pull/30.patch","issue_url":"https://api.github.com/repos/donaldduck/testrepo/issues/30","number":30,"state":"open","locked":false,"title":"Title","user":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"body":"Description","created_at":"2018-01-25T21:18:53Z","updated_at":"2018-01-25T21:18:53Z","closed_at":null,"merged_at":null,"merge_commit_sha":null,"assignee":null,"assignees":[],"requested_reviewers":[],"requested_teams":[],"milestone":null,"commits_url":"https://api.github.com/repos/donaldduck/testrepo/pulls/30/commits","review_comments_url":"https://api.github.com/repos/donaldduck/testrepo/pulls/30/comments","review_comment_url":"https://api.github.com/repos/donaldduck/testrepo/pulls/comments{/number}","comments_url":"https://api.github.com/repos/donaldduck/testrepo/issues/30/comments","statuses_url":"https://api.github.com/repos/donaldduck/testrepo/statuses/16aaf0dedd31dd7646dd1a9fa3cc1d911541bf49","head":{"label":"donaldduck:mybranch","ref":"mybranch","sha":"16aaf0dedd31dd7646dd1a9fa3cc1d911541bf49","user":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"repo":{"id":123456754,"name":"testrepo","full_name":"donaldduck/testrepo","owner":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"private":true,"html_url":"https://github.com/donaldduck/testrepo","description":null,"fork":true,"url":"https://api.github.com/repos/donaldduck/testrepo","forks_url":"https://api.github.com/repos/donaldduck/testrepo/forks","keys_url":"https://api.github.com/repos/donaldduck/testrepo/keys{/key_id}","collaborators_url":"https://api.github.com/repos/donaldduck/testrepo/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/donaldduck/testrepo/teams","hooks_url":"https://api.github.com/repos/donaldduck/testrepo/hooks","issue_events_url":"https://api.github.com/repos/donaldduck/testrepo/issues/events{/number}","events_url":"https://api.github.com/repos/donaldduck/testrepo/events","assignees_url":"https://api.github.com/repos/donaldduck/testrepo/assignees{/user}","branches_url":"https://api.github.com/repos/donaldduck/testrepo/branches{/branch}","tags_url":"https://api.github.com/repos/donaldduck/testrepo/tags","blobs_url":"https://api.github.com/repos/donaldduck/testrepo/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/donaldduck/testrepo/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/donaldduck/testrepo/git/refs{/sha}","trees_url":"https://api.github.com/repos/donaldduck/testrepo/git/trees{/sha}","statuses_url":"https://api.github.com/repos/donaldduck/testrepo/statuses/{sha}","languages_url":"https://api.github.com/repos/donaldduck/testrepo/languages","stargazers_url":"https://api.github.com/repos/donaldduck/testrepo/stargazers","contributors_url":"https://api.github.com/repos/donaldduck/testrepo/contributors","subscribers_url":"https://api.github.com/repos/donaldduck/testrepo/subscribers","subscription_url":"https://api.github.com/repos/donaldduck/testrepo/subscription","commits_url":"https://api.github.com/repos/donaldduck/testrepo/commits{/sha}","git_commits_url":"https://api.github.com/repos/donaldduck/testrepo/git/commits{/sha}","comments_url":"https://api.github.com/repos/donaldduck/testrepo/comments{/number}","issue_comment_url":"https://api.github.com/repos/donaldduck/testrepo/issues/comments{/number}","contents_url":"https://api.github.com/repos/donaldduck/testrepo/contents/{+path}","compare_url":"https://api.github.com/repos/donaldduck/testrepo/compare/{base}...{head}","merges_url":"https://api.github.com/repos/donaldduck/testrepo/merges","archive_url":"https://api.github.com/repos/donaldduck/testrepo/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/donaldduck/testrepo/downloads","issues_url":"https://api.github.com/repos/donaldduck/testrepo/issues{/number}","pulls_url":"https://api.github.com/repos/donaldduck/testrepo/pulls{/number}","milestones_url":"https://api.github.com/repos/donaldduck/testrepo/milestones{/number}","notifications_url":"https://api.github.com/repos/donaldduck/testrepo/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/donaldduck/testrepo/labels{/name}","releases_url":"https://api.github.com/repos/donaldduck/testrepo/releases{/id}","deployments_url":"https://api.github.com/repos/donaldduck/testrepo/deployments","created_at":"2017-12-23T18:58:57Z","updated_at":"2018-01-25T21:16:23Z","pushed_at":"2018-01-25T21:18:52Z","git_url":"git://github.com/donaldduck/testrepo.git","ssh_url":"git@github.com:donaldduck/testrepo.git","clone_url":"https://github.com/donaldduck/testrepo.git","svn_url":"https://github.com/donaldduck/testrepo","homepage":null,"size":15,"stargazers_count":0,"watchers_count":0,"language":"Ruby","has_issues":true,"has_projects":false,"has_downloads":true,"has_wiki":false,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"open_issues_count":9,"license":null,"forks":0,"open_issues":9,"watchers":0,"default_branch":"master"}},"base":{"label":"donaldduck:master","ref":"master","sha":"05e7bf92117c784e6d17194f1a07c8258bbc8d3a","user":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"repo":{"id":123456754,"name":"testrepo","full_name":"donaldduck/testrepo","owner":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"private":true,"html_url":"https://github.com/donaldduck/testrepo","description":null,"fork":true,"url":"https://api.github.com/repos/donaldduck/testrepo","forks_url":"https://api.github.com/repos/donaldduck/testrepo/forks","keys_url":"https://api.github.com/repos/donaldduck/testrepo/keys{/key_id}","collaborators_url":"https://api.github.com/repos/donaldduck/testrepo/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/donaldduck/testrepo/teams","hooks_url":"https://api.github.com/repos/donaldduck/testrepo/hooks","issue_events_url":"https://api.github.com/repos/donaldduck/testrepo/issues/events{/number}","events_url":"https://api.github.com/repos/donaldduck/testrepo/events","assignees_url":"https://api.github.com/repos/donaldduck/testrepo/assignees{/user}","branches_url":"https://api.github.com/repos/donaldduck/testrepo/branches{/branch}","tags_url":"https://api.github.com/repos/donaldduck/testrepo/tags","blobs_url":"https://api.github.com/repos/donaldduck/testrepo/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/donaldduck/testrepo/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/donaldduck/testrepo/git/refs{/sha}","trees_url":"https://api.github.com/repos/donaldduck/testrepo/git/trees{/sha}","statuses_url":"https://api.github.com/repos/donaldduck/testrepo/statuses/{sha}","languages_url":"https://api.github.com/repos/donaldduck/testrepo/languages","stargazers_url":"https://api.github.com/repos/donaldduck/testrepo/stargazers","contributors_url":"https://api.github.com/repos/donaldduck/testrepo/contributors","subscribers_url":"https://api.github.com/repos/donaldduck/testrepo/subscribers","subscription_url":"https://api.github.com/repos/donaldduck/testrepo/subscription","commits_url":"https://api.github.com/repos/donaldduck/testrepo/commits{/sha}","git_commits_url":"https://api.github.com/repos/donaldduck/testrepo/git/commits{/sha}","comments_url":"https://api.github.com/repos/donaldduck/testrepo/comments{/number}","issue_comment_url":"https://api.github.com/repos/donaldduck/testrepo/issues/comments{/number}","contents_url":"https://api.github.com/repos/donaldduck/testrepo/contents/{+path}","compare_url":"https://api.github.com/repos/donaldduck/testrepo/compare/{base}...{head}","merges_url":"https://api.github.com/repos/donaldduck/testrepo/merges","archive_url":"https://api.github.com/repos/donaldduck/testrepo/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/donaldduck/testrepo/downloads","issues_url":"https://api.github.com/repos/donaldduck/testrepo/issues{/number}","pulls_url":"https://api.github.com/repos/donaldduck/testrepo/pulls{/number}","milestones_url":"https://api.github.com/repos/donaldduck/testrepo/milestones{/number}","notifications_url":"https://api.github.com/repos/donaldduck/testrepo/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/donaldduck/testrepo/labels{/name}","releases_url":"https://api.github.com/repos/donaldduck/testrepo/releases{/id}","deployments_url":"https://api.github.com/repos/donaldduck/testrepo/deployments","created_at":"2017-12-23T18:58:57Z","updated_at":"2018-01-25T21:16:23Z","pushed_at":"2018-01-25T21:18:52Z","git_url":"git://github.com/donaldduck/testrepo.git","ssh_url":"git@github.com:donaldduck/testrepo.git","clone_url":"https://github.com/donaldduck/testrepo.git","svn_url":"https://github.com/donaldduck/testrepo","homepage":null,"size":15,"stargazers_count":0,"watchers_count":0,"language":"Ruby","has_issues":true,"has_projects":false,"has_downloads":true,"has_wiki":false,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"open_issues_count":9,"license":null,"forks":0,"open_issues":9,"watchers":0,"default_branch":"master"}},"_links":{"self":{"href":"https://api.github.com/repos/donaldduck/testrepo/pulls/30"},"html":{"href":"https://github.com/donaldduck/testrepo/pull/30"},"issue":{"href":"https://api.github.com/repos/donaldduck/testrepo/issues/30"},"comments":{"href":"https://api.github.com/repos/donaldduck/testrepo/issues/30/comments"},"review_comments":{"href":"https://api.github.com/repos/donaldduck/testrepo/pulls/30/comments"},"review_comment":{"href":"https://api.github.com/repos/donaldduck/testrepo/pulls/comments{/number}"},"commits":{"href":"https://api.github.com/repos/donaldduck/testrepo/pulls/30/commits"},"statuses":{"href":"https://api.github.com/repos/donaldduck/testrepo/statuses/16aaf0dedd31dd7646dd1a9fa3cc1d911541bf49"}},"author_association":"COLLABORATOR","merged":false,"mergeable":null,"rebaseable":null,"mergeable_state":"unknown","merged_by":null,"comments":0,"review_comments":0,"maintainer_can_modify":false,"commits":2,"additions":0,"deletions":0,"changed_files":2}'
+      string: ''
     http_version: 
-  recorded_at: Thu, 25 Jan 2018 21:18:53 GMT
+  recorded_at: Mon, 05 Feb 2018 21:32:50 GMT
 - request:
     method: get
     uri: https://api.github.com/user
@@ -102,7 +170,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Thu, 25 Jan 2018 21:18:54 GMT
+      - Mon, 05 Feb 2018 21:32:50 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -112,17 +180,17 @@ http_interactions:
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4998'
+      - '4942'
       X-Ratelimit-Reset:
-      - '1516918733'
+      - '1517867477'
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Vary:
       - Accept, Authorization, Cookie, X-GitHub-OTP
       Etag:
-      - W/ffffffff37a5711fb4b6e55e9deba9da1"
+      - W/"867a7455cae6fa03110405ae3f4f8ffe"
       Last-Modified:
-      - Fri, 19 Jan 2018 08:36:16 GMT
+      - Tue, 30 Jan 2018 20:56:34 GMT
       X-Oauth-Scopes:
       - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
         delete_repo, gist, notifications, repo, user
@@ -146,18 +214,326 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Runtime-Rack:
-      - '0.053067'
+      - '0.049188'
       X-Github-Request-Id:
-      - C646:1DEA:16E10D1:FFFFFFF:5A6A49BE
+      - E64A:14EB:257DCFE:528E12C:5A78CD82
     body:
       encoding: ASCII-8BIT
       string: '{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false,"name":"Donald
-        Duck","company":"@mickeymouselaws","blog":"","location":"Berlin","email":"donald.pub2@gmail.com","hireable":true,"bio":null,"public_repos":16,"public_gists":0,"followers":9,"following":0,"created_at":"2012-04-01T11:52:16Z","updated_at":"2018-01-19T08:36:16Z","private_gists":0,"total_private_repos":1,"owned_private_repos":0,"disk_usage":32519,"collaborators":0,"two_factor_authentication":true,"plan":{"name":"free","space":976562499,"collaborators":0,"private_repos":0}}'
+        Duck","company":"@momcorp","blog":"","location":"Berlin","email":"donald.pub2@gmail.com","hireable":true,"bio":null,"public_repos":19,"public_gists":0,"followers":9,"following":0,"created_at":"2012-04-01T11:52:16Z","updated_at":"2018-01-30T20:56:34Z","private_gists":0,"total_private_repos":0,"owned_private_repos":0,"disk_usage":32597,"collaborators":0,"two_factor_authentication":true,"plan":{"name":"free","space":976562499,"collaborators":0,"private_repos":0}}'
     http_version: 
-  recorded_at: Thu, 25 Jan 2018 21:18:54 GMT
+  recorded_at: Mon, 05 Feb 2018 21:32:51 GMT
+- request:
+    method: get
+    uri: https://api.github.com/user
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Ruby
+      Host:
+      - api.github.com
+      Authorization:
+      - Basic <GITHUB_CREDENTIALS>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Mon, 05 Feb 2018 21:32:51 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4941'
+      X-Ratelimit-Reset:
+      - '1517867477'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      Etag:
+      - W/"867a7455cae6fa03110405ae3f4f8ffe"
+      Last-Modified:
+      - Tue, 30 Jan 2018 20:56:34 GMT
+      X-Oauth-Scopes:
+      - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
+        delete_repo, gist, notifications, repo, user
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - default-src 'none'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Runtime-Rack:
+      - '0.054808'
+      X-Github-Request-Id:
+      - E64C:14EB:257DD37:528E18A:5A78CD83
+    body:
+      encoding: ASCII-8BIT
+      string: '{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false,"name":"Donald
+        Duck","company":"@momcorp","blog":"","location":"Berlin","email":"donald.pub2@gmail.com","hireable":true,"bio":null,"public_repos":19,"public_gists":0,"followers":9,"following":0,"created_at":"2012-04-01T11:52:16Z","updated_at":"2018-01-30T20:56:34Z","private_gists":0,"total_private_repos":0,"owned_private_repos":0,"disk_usage":32597,"collaborators":0,"two_factor_authentication":true,"plan":{"name":"free","space":976562499,"collaborators":0,"private_repos":0}}'
+    http_version: 
+  recorded_at: Mon, 05 Feb 2018 21:32:51 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/donaldduck/testrepo_f/collaborators/donaldduck/permission
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Ruby
+      Host:
+      - api.github.com
+      Authorization:
+      - Basic <GITHUB_CREDENTIALS>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Mon, 05 Feb 2018 21:32:52 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4940'
+      X-Ratelimit-Reset:
+      - '1517867477'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      Etag:
+      - W/"2e0eb2906871bf26051feba70dcc7ce1"
+      X-Oauth-Scopes:
+      - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
+        delete_repo, gist, notifications, repo, user
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - default-src 'none'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Runtime-Rack:
+      - '0.029823'
+      X-Github-Request-Id:
+      - E64E:14ED:3FA6783:804E67D:5A78CD84
+    body:
+      encoding: ASCII-8BIT
+      string: '{"permission":"admin","user":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false}}'
+    http_version: 
+  recorded_at: Mon, 05 Feb 2018 21:32:52 GMT
 - request:
     method: post
-    uri: https://api.github.com/repos/donaldduck/testrepo/issues/30/assignees
+    uri: https://api.github.com/repos/donaldduck/testrepo_f/pulls
+    body:
+      encoding: UTF-8
+      string: '{"title":"Title","body":"Description","head":"mybranch","base":"master"}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Ruby
+      Host:
+      - api.github.com
+      Authorization:
+      - Basic <GITHUB_CREDENTIALS>
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Mon, 05 Feb 2018 21:32:57 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '15314'
+      Status:
+      - 201 Created
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4939'
+      X-Ratelimit-Reset:
+      - '1517867477'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      Etag:
+      - '"5fcff9a68b79538659f30e1d4f1d49f1"'
+      X-Oauth-Scopes:
+      - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
+        delete_repo, gist, notifications, repo, user
+      X-Accepted-Oauth-Scopes:
+      - ''
+      Location:
+      - https://api.github.com/repos/donaldduck/testrepo_f/pulls/4
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - default-src 'none'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Runtime-Rack:
+      - '0.273376'
+      X-Github-Request-Id:
+      - B094:14ED:3FA6A0E:804EB97:5A78CD89
+    body:
+      encoding: UTF-8
+      string: '{"url":"https://api.github.com/repos/donaldduck/testrepo_f/pulls/4","id":123456182,"html_url":"https://github.com/donaldduck/testrepo_f/pull/4","diff_url":"https://github.com/donaldduck/testrepo_f/pull/4.diff","patch_url":"https://github.com/donaldduck/testrepo_f/pull/4.patch","issue_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/4","number":4,"state":"open","locked":false,"title":"Title","user":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"body":"Description","created_at":"2018-02-05T21:32:57Z","updated_at":"2018-02-05T21:32:57Z","closed_at":null,"merged_at":null,"merge_commit_sha":null,"assignee":null,"assignees":[],"requested_reviewers":[],"requested_teams":[],"milestone":null,"commits_url":"https://api.github.com/repos/donaldduck/testrepo_f/pulls/4/commits","review_comments_url":"https://api.github.com/repos/donaldduck/testrepo_f/pulls/4/comments","review_comment_url":"https://api.github.com/repos/donaldduck/testrepo_f/pulls/comments{/number}","comments_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/4/comments","statuses_url":"https://api.github.com/repos/donaldduck/testrepo_f/statuses/2ed302a6c2b3bbfab51c64321b20b854017b97ee","head":{"label":"donaldduck:mybranch","ref":"mybranch","sha":"2ed302a6c2b3bbfab51c64321b20b854017b97ee","user":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"repo":{"id":123456502,"name":"testrepo_f","full_name":"donaldduck/testrepo_f","owner":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"private":false,"html_url":"https://github.com/donaldduck/testrepo_f","description":null,"fork":true,"url":"https://api.github.com/repos/donaldduck/testrepo_f","forks_url":"https://api.github.com/repos/donaldduck/testrepo_f/forks","keys_url":"https://api.github.com/repos/donaldduck/testrepo_f/keys{/key_id}","collaborators_url":"https://api.github.com/repos/donaldduck/testrepo_f/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/donaldduck/testrepo_f/teams","hooks_url":"https://api.github.com/repos/donaldduck/testrepo_f/hooks","issue_events_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/events{/number}","events_url":"https://api.github.com/repos/donaldduck/testrepo_f/events","assignees_url":"https://api.github.com/repos/donaldduck/testrepo_f/assignees{/user}","branches_url":"https://api.github.com/repos/donaldduck/testrepo_f/branches{/branch}","tags_url":"https://api.github.com/repos/donaldduck/testrepo_f/tags","blobs_url":"https://api.github.com/repos/donaldduck/testrepo_f/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/donaldduck/testrepo_f/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/donaldduck/testrepo_f/git/refs{/sha}","trees_url":"https://api.github.com/repos/donaldduck/testrepo_f/git/trees{/sha}","statuses_url":"https://api.github.com/repos/donaldduck/testrepo_f/statuses/{sha}","languages_url":"https://api.github.com/repos/donaldduck/testrepo_f/languages","stargazers_url":"https://api.github.com/repos/donaldduck/testrepo_f/stargazers","contributors_url":"https://api.github.com/repos/donaldduck/testrepo_f/contributors","subscribers_url":"https://api.github.com/repos/donaldduck/testrepo_f/subscribers","subscription_url":"https://api.github.com/repos/donaldduck/testrepo_f/subscription","commits_url":"https://api.github.com/repos/donaldduck/testrepo_f/commits{/sha}","git_commits_url":"https://api.github.com/repos/donaldduck/testrepo_f/git/commits{/sha}","comments_url":"https://api.github.com/repos/donaldduck/testrepo_f/comments{/number}","issue_comment_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/comments{/number}","contents_url":"https://api.github.com/repos/donaldduck/testrepo_f/contents/{+path}","compare_url":"https://api.github.com/repos/donaldduck/testrepo_f/compare/{base}...{head}","merges_url":"https://api.github.com/repos/donaldduck/testrepo_f/merges","archive_url":"https://api.github.com/repos/donaldduck/testrepo_f/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/donaldduck/testrepo_f/downloads","issues_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues{/number}","pulls_url":"https://api.github.com/repos/donaldduck/testrepo_f/pulls{/number}","milestones_url":"https://api.github.com/repos/donaldduck/testrepo_f/milestones{/number}","notifications_url":"https://api.github.com/repos/donaldduck/testrepo_f/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/donaldduck/testrepo_f/labels{/name}","releases_url":"https://api.github.com/repos/donaldduck/testrepo_f/releases{/id}","deployments_url":"https://api.github.com/repos/donaldduck/testrepo_f/deployments","created_at":"2018-02-05T20:44:53Z","updated_at":"2018-02-05T21:04:59Z","pushed_at":"2018-02-05T21:32:56Z","git_url":"git://github.com/donaldduck/testrepo_f.git","ssh_url":"git@github.com:donaldduck/testrepo_f.git","clone_url":"https://github.com/donaldduck/testrepo_f.git","svn_url":"https://github.com/donaldduck/testrepo_f","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":false,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"open_issues_count":1,"license":null,"forks":0,"open_issues":1,"watchers":0,"default_branch":"master"}},"base":{"label":"donaldduck:master","ref":"master","sha":"c971bf0ec8076e78b866a41ba4c3a83bc6a4be73","user":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"repo":{"id":123456502,"name":"testrepo_f","full_name":"donaldduck/testrepo_f","owner":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"private":false,"html_url":"https://github.com/donaldduck/testrepo_f","description":null,"fork":true,"url":"https://api.github.com/repos/donaldduck/testrepo_f","forks_url":"https://api.github.com/repos/donaldduck/testrepo_f/forks","keys_url":"https://api.github.com/repos/donaldduck/testrepo_f/keys{/key_id}","collaborators_url":"https://api.github.com/repos/donaldduck/testrepo_f/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/donaldduck/testrepo_f/teams","hooks_url":"https://api.github.com/repos/donaldduck/testrepo_f/hooks","issue_events_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/events{/number}","events_url":"https://api.github.com/repos/donaldduck/testrepo_f/events","assignees_url":"https://api.github.com/repos/donaldduck/testrepo_f/assignees{/user}","branches_url":"https://api.github.com/repos/donaldduck/testrepo_f/branches{/branch}","tags_url":"https://api.github.com/repos/donaldduck/testrepo_f/tags","blobs_url":"https://api.github.com/repos/donaldduck/testrepo_f/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/donaldduck/testrepo_f/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/donaldduck/testrepo_f/git/refs{/sha}","trees_url":"https://api.github.com/repos/donaldduck/testrepo_f/git/trees{/sha}","statuses_url":"https://api.github.com/repos/donaldduck/testrepo_f/statuses/{sha}","languages_url":"https://api.github.com/repos/donaldduck/testrepo_f/languages","stargazers_url":"https://api.github.com/repos/donaldduck/testrepo_f/stargazers","contributors_url":"https://api.github.com/repos/donaldduck/testrepo_f/contributors","subscribers_url":"https://api.github.com/repos/donaldduck/testrepo_f/subscribers","subscription_url":"https://api.github.com/repos/donaldduck/testrepo_f/subscription","commits_url":"https://api.github.com/repos/donaldduck/testrepo_f/commits{/sha}","git_commits_url":"https://api.github.com/repos/donaldduck/testrepo_f/git/commits{/sha}","comments_url":"https://api.github.com/repos/donaldduck/testrepo_f/comments{/number}","issue_comment_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/comments{/number}","contents_url":"https://api.github.com/repos/donaldduck/testrepo_f/contents/{+path}","compare_url":"https://api.github.com/repos/donaldduck/testrepo_f/compare/{base}...{head}","merges_url":"https://api.github.com/repos/donaldduck/testrepo_f/merges","archive_url":"https://api.github.com/repos/donaldduck/testrepo_f/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/donaldduck/testrepo_f/downloads","issues_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues{/number}","pulls_url":"https://api.github.com/repos/donaldduck/testrepo_f/pulls{/number}","milestones_url":"https://api.github.com/repos/donaldduck/testrepo_f/milestones{/number}","notifications_url":"https://api.github.com/repos/donaldduck/testrepo_f/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/donaldduck/testrepo_f/labels{/name}","releases_url":"https://api.github.com/repos/donaldduck/testrepo_f/releases{/id}","deployments_url":"https://api.github.com/repos/donaldduck/testrepo_f/deployments","created_at":"2018-02-05T20:44:53Z","updated_at":"2018-02-05T21:04:59Z","pushed_at":"2018-02-05T21:32:56Z","git_url":"git://github.com/donaldduck/testrepo_f.git","ssh_url":"git@github.com:donaldduck/testrepo_f.git","clone_url":"https://github.com/donaldduck/testrepo_f.git","svn_url":"https://github.com/donaldduck/testrepo_f","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":false,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"open_issues_count":1,"license":null,"forks":0,"open_issues":1,"watchers":0,"default_branch":"master"}},"_links":{"self":{"href":"https://api.github.com/repos/donaldduck/testrepo_f/pulls/4"},"html":{"href":"https://github.com/donaldduck/testrepo_f/pull/4"},"issue":{"href":"https://api.github.com/repos/donaldduck/testrepo_f/issues/4"},"comments":{"href":"https://api.github.com/repos/donaldduck/testrepo_f/issues/4/comments"},"review_comments":{"href":"https://api.github.com/repos/donaldduck/testrepo_f/pulls/4/comments"},"review_comment":{"href":"https://api.github.com/repos/donaldduck/testrepo_f/pulls/comments{/number}"},"commits":{"href":"https://api.github.com/repos/donaldduck/testrepo_f/pulls/4/commits"},"statuses":{"href":"https://api.github.com/repos/donaldduck/testrepo_f/statuses/2ed302a6c2b3bbfab51c64321b20b854017b97ee"}},"author_association":"OWNER","merged":false,"mergeable":null,"rebaseable":null,"mergeable_state":"unknown","merged_by":null,"comments":0,"review_comments":0,"maintainer_can_modify":false,"commits":1,"additions":0,"deletions":0,"changed_files":1}'
+    http_version: 
+  recorded_at: Mon, 05 Feb 2018 21:32:58 GMT
+- request:
+    method: get
+    uri: https://api.github.com/user
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Ruby
+      Host:
+      - api.github.com
+      Authorization:
+      - Basic <GITHUB_CREDENTIALS>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Mon, 05 Feb 2018 21:32:59 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4938'
+      X-Ratelimit-Reset:
+      - '1517867477'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      Etag:
+      - W/"867a7455cae6fa03110405ae3f4f8ffe"
+      Last-Modified:
+      - Tue, 30 Jan 2018 20:56:34 GMT
+      X-Oauth-Scopes:
+      - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
+        delete_repo, gist, notifications, repo, user
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - default-src 'none'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Runtime-Rack:
+      - '0.054647'
+      X-Github-Request-Id:
+      - E654:14EE:3742487:857C89E:5A78CD8A
+    body:
+      encoding: ASCII-8BIT
+      string: '{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false,"name":"Donald
+        Duck","company":"@momcorp","blog":"","location":"Berlin","email":"donald.pub2@gmail.com","hireable":true,"bio":null,"public_repos":19,"public_gists":0,"followers":9,"following":0,"created_at":"2012-04-01T11:52:16Z","updated_at":"2018-01-30T20:56:34Z","private_gists":0,"total_private_repos":0,"owned_private_repos":0,"disk_usage":32597,"collaborators":0,"two_factor_authentication":true,"plan":{"name":"free","space":976562499,"collaborators":0,"private_repos":0}}'
+    http_version: 
+  recorded_at: Mon, 05 Feb 2018 21:32:59 GMT
+- request:
+    method: post
+    uri: https://api.github.com/repos/donaldduck/testrepo_f/issues/4/assignees
     body:
       encoding: UTF-8
       string: '{"assignees":["donaldduck"]}'
@@ -180,32 +556,32 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Thu, 25 Jan 2018 21:18:55 GMT
+      - Mon, 05 Feb 2018 21:33:00 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '3896'
+      - '3899'
       Status:
       - 201 Created
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4997'
+      - '4937'
       X-Ratelimit-Reset:
-      - '1516918733'
+      - '1517867477'
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Vary:
       - Accept, Authorization, Cookie, X-GitHub-OTP
       Etag:
-      - '"ffffffff238e42287a920b928b0c26ad"'
+      - '"bb4ccafb78223cdfee1f9904a9af7cbd"'
       X-Oauth-Scopes:
       - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
         delete_repo, gist, notifications, repo, user
       X-Accepted-Oauth-Scopes:
       - ''
       Location:
-      - https://api.github.com/repos/donaldduck/testrepo/issues/30
+      - https://api.github.com/repos/donaldduck/testrepo_f/issues/4
       X-Github-Media-Type:
       - github.v3; format=json
       Access-Control-Expose-Headers:
@@ -224,12 +600,12 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Runtime-Rack:
-      - '0.188529'
+      - '0.179592'
       X-Github-Request-Id:
-      - C648:1DEA:16E1165:FFFFFFF:5A6A49BF
+      - B098:14EC:2FB7631:66274E1:5A78CD8B
     body:
       encoding: UTF-8
-      string: '{"url":"https://api.github.com/repos/donaldduck/testrepo/issues/30","repository_url":"https://api.github.com/repos/donaldduck/testrepo","labels_url":"https://api.github.com/repos/donaldduck/testrepo/issues/30/labels{/name}","comments_url":"https://api.github.com/repos/donaldduck/testrepo/issues/30/comments","events_url":"https://api.github.com/repos/donaldduck/testrepo/issues/30/events","html_url":"https://github.com/donaldduck/testrepo/pull/30","id":123456068,"number":30,"title":"Title","user":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"labels":[],"state":"open","locked":false,"assignee":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"assignees":[{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false}],"milestone":null,"comments":0,"created_at":"2018-01-25T21:18:53Z","updated_at":"2018-01-25T21:18:55Z","closed_at":null,"author_association":"COLLABORATOR","pull_request":{"url":"https://api.github.com/repos/donaldduck/testrepo/pulls/30","html_url":"https://github.com/donaldduck/testrepo/pull/30","diff_url":"https://github.com/donaldduck/testrepo/pull/30.diff","patch_url":"https://github.com/donaldduck/testrepo/pull/30.patch"},"body":"Description"}'
+      string: '{"url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/4","repository_url":"https://api.github.com/repos/donaldduck/testrepo_f","labels_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/4/labels{/name}","comments_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/4/comments","events_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/4/events","html_url":"https://github.com/donaldduck/testrepo_f/pull/4","id":123456646,"number":4,"title":"Title","user":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"labels":[],"state":"open","locked":false,"assignee":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"assignees":[{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false}],"milestone":null,"comments":0,"created_at":"2018-02-05T21:32:57Z","updated_at":"2018-02-05T21:33:00Z","closed_at":null,"author_association":"OWNER","pull_request":{"url":"https://api.github.com/repos/donaldduck/testrepo_f/pulls/4","html_url":"https://github.com/donaldduck/testrepo_f/pull/4","diff_url":"https://github.com/donaldduck/testrepo_f/pull/4.diff","patch_url":"https://github.com/donaldduck/testrepo_f/pull/4.patch"},"body":"Description"}'
     http_version: 
-  recorded_at: Thu, 25 Jan 2018 21:18:55 GMT
+  recorded_at: Mon, 05 Feb 2018 21:33:00 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/create_pr_in_auto_mode_with_push.yml
+++ b/spec/vcr_cassettes/create_pr_in_auto_mode_with_push.yml
@@ -1,11 +1,11 @@
 ---
 http_interactions:
 - request:
-    method: post
-    uri: https://api.github.com/repos/donaldduck/testrepo/pulls
+    method: get
+    uri: https://api.github.com/user
     body:
-      encoding: UTF-8
-      string: '{"title":"Title","body":"Description","head":"mybranch","base":"master"}'
+      encoding: US-ASCII
+      string: ''
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -19,38 +19,38 @@ http_interactions:
       - Basic <GITHUB_CREDENTIALS>
   response:
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
     headers:
       Server:
       - GitHub.com
       Date:
-      - Thu, 25 Jan 2018 21:02:20 GMT
+      - Mon, 05 Feb 2018 21:26:34 GMT
       Content-Type:
       - application/json; charset=utf-8
-      Content-Length:
-      - '15448'
+      Transfer-Encoding:
+      - chunked
       Status:
-      - 201 Created
+      - 200 OK
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4970'
+      - '4960'
       X-Ratelimit-Reset:
-      - '1516915084'
+      - '1517867477'
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Vary:
       - Accept, Authorization, Cookie, X-GitHub-OTP
       Etag:
-      - '"ffffffffc942f42b158e09616f3dc24f"'
+      - W/"867a7455cae6fa03110405ae3f4f8ffe"
+      Last-Modified:
+      - Tue, 30 Jan 2018 20:56:34 GMT
       X-Oauth-Scopes:
       - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
         delete_repo, gist, notifications, repo, user
       X-Accepted-Oauth-Scopes:
       - ''
-      Location:
-      - https://api.github.com/repos/donaldduck/testrepo/pulls/29
       X-Github-Media-Type:
       - github.v3; format=json
       Access-Control-Expose-Headers:
@@ -69,14 +69,82 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Runtime-Rack:
-      - '0.342454'
+      - '0.062723'
       X-Github-Request-Id:
-      - 86F4:1DEC:207619F:FF7FCFF:5A6A45DC
+      - B02A:14EB:2576377:527D7C8:5A78CC0A
+    body:
+      encoding: ASCII-8BIT
+      string: '{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false,"name":"Donald
+        Duck","company":"@momcorp","blog":"","location":"Berlin","email":"donald.pub2@gmail.com","hireable":true,"bio":null,"public_repos":19,"public_gists":0,"followers":9,"following":0,"created_at":"2012-04-01T11:52:16Z","updated_at":"2018-01-30T20:56:34Z","private_gists":0,"total_private_repos":0,"owned_private_repos":0,"disk_usage":32597,"collaborators":0,"two_factor_authentication":true,"plan":{"name":"free","space":976562499,"collaborators":0,"private_repos":0}}'
+    http_version: 
+  recorded_at: Mon, 05 Feb 2018 21:26:35 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/donaldduck/testrepo_f/collaborators/donaldduck
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Ruby
+      Host:
+      - api.github.com
+      Authorization:
+      - Basic <GITHUB_CREDENTIALS>
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Mon, 05 Feb 2018 21:26:36 GMT
+      Content-Type:
+      - application/octet-stream
+      Status:
+      - 204 No Content
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4959'
+      X-Ratelimit-Reset:
+      - '1517867477'
+      X-Oauth-Scopes:
+      - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
+        delete_repo, gist, notifications, repo, user
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - default-src 'none'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Runtime-Rack:
+      - '0.056635'
+      X-Github-Request-Id:
+      - E5EA:14EC:2FAECE0:6614B37:5A78CC0B
     body:
       encoding: UTF-8
-      string: '{"url":"https://api.github.com/repos/donaldduck/testrepo/pulls/29","id":123456397,"html_url":"https://github.com/donaldduck/testrepo/pull/29","diff_url":"https://github.com/donaldduck/testrepo/pull/29.diff","patch_url":"https://github.com/donaldduck/testrepo/pull/29.patch","issue_url":"https://api.github.com/repos/donaldduck/testrepo/issues/29","number":29,"state":"open","locked":false,"title":"Title","user":{"login":"donaldduck","id":1234560,"avatar_url":"https://avatars2.githubusercontent.com/u/3505400?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"body":"Description","created_at":"2018-01-25T21:02:20Z","updated_at":"2018-01-25T21:02:20Z","closed_at":null,"merged_at":null,"merge_commit_sha":null,"assignee":null,"assignees":[],"requested_reviewers":[],"requested_teams":[],"milestone":null,"commits_url":"https://api.github.com/repos/donaldduck/testrepo/pulls/29/commits","review_comments_url":"https://api.github.com/repos/donaldduck/testrepo/pulls/29/comments","review_comment_url":"https://api.github.com/repos/donaldduck/testrepo/pulls/comments{/number}","comments_url":"https://api.github.com/repos/donaldduck/testrepo/issues/29/comments","statuses_url":"https://api.github.com/repos/donaldduck/testrepo/statuses/16aaf0dedd31dd7646dd1a9fa3cc1d911541bf49","head":{"label":"donaldduck:mybranch","ref":"mybranch","sha":"16aaf0dedd31dd7646dd1a9fa3cc1d911541bf49","user":{"login":"donaldduck","id":1234560,"avatar_url":"https://avatars2.githubusercontent.com/u/3505400?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"repo":{"id":123456955,"name":"testrepo","full_name":"donaldduck/testrepo","owner":{"login":"donaldduck","id":1234560,"avatar_url":"https://avatars2.githubusercontent.com/u/3505400?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"private":true,"html_url":"https://github.com/donaldduck/testrepo","description":null,"fork":true,"url":"https://api.github.com/repos/donaldduck/testrepo","forks_url":"https://api.github.com/repos/donaldduck/testrepo/forks","keys_url":"https://api.github.com/repos/donaldduck/testrepo/keys{/key_id}","collaborators_url":"https://api.github.com/repos/donaldduck/testrepo/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/donaldduck/testrepo/teams","hooks_url":"https://api.github.com/repos/donaldduck/testrepo/hooks","issue_events_url":"https://api.github.com/repos/donaldduck/testrepo/issues/events{/number}","events_url":"https://api.github.com/repos/donaldduck/testrepo/events","assignees_url":"https://api.github.com/repos/donaldduck/testrepo/assignees{/user}","branches_url":"https://api.github.com/repos/donaldduck/testrepo/branches{/branch}","tags_url":"https://api.github.com/repos/donaldduck/testrepo/tags","blobs_url":"https://api.github.com/repos/donaldduck/testrepo/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/donaldduck/testrepo/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/donaldduck/testrepo/git/refs{/sha}","trees_url":"https://api.github.com/repos/donaldduck/testrepo/git/trees{/sha}","statuses_url":"https://api.github.com/repos/donaldduck/testrepo/statuses/{sha}","languages_url":"https://api.github.com/repos/donaldduck/testrepo/languages","stargazers_url":"https://api.github.com/repos/donaldduck/testrepo/stargazers","contributors_url":"https://api.github.com/repos/donaldduck/testrepo/contributors","subscribers_url":"https://api.github.com/repos/donaldduck/testrepo/subscribers","subscription_url":"https://api.github.com/repos/donaldduck/testrepo/subscription","commits_url":"https://api.github.com/repos/donaldduck/testrepo/commits{/sha}","git_commits_url":"https://api.github.com/repos/donaldduck/testrepo/git/commits{/sha}","comments_url":"https://api.github.com/repos/donaldduck/testrepo/comments{/number}","issue_comment_url":"https://api.github.com/repos/donaldduck/testrepo/issues/comments{/number}","contents_url":"https://api.github.com/repos/donaldduck/testrepo/contents/{+path}","compare_url":"https://api.github.com/repos/donaldduck/testrepo/compare/{base}...{head}","merges_url":"https://api.github.com/repos/donaldduck/testrepo/merges","archive_url":"https://api.github.com/repos/donaldduck/testrepo/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/donaldduck/testrepo/downloads","issues_url":"https://api.github.com/repos/donaldduck/testrepo/issues{/number}","pulls_url":"https://api.github.com/repos/donaldduck/testrepo/pulls{/number}","milestones_url":"https://api.github.com/repos/donaldduck/testrepo/milestones{/number}","notifications_url":"https://api.github.com/repos/donaldduck/testrepo/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/donaldduck/testrepo/labels{/name}","releases_url":"https://api.github.com/repos/donaldduck/testrepo/releases{/id}","deployments_url":"https://api.github.com/repos/donaldduck/testrepo/deployments","created_at":"2017-12-23T18:58:57Z","updated_at":"2017-12-23T19:00:02Z","pushed_at":"2018-01-25T21:02:19Z","git_url":"git://github.com/donaldduck/testrepo.git","ssh_url":"git@github.com:donaldduck/testrepo.git","clone_url":"https://github.com/donaldduck/testrepo.git","svn_url":"https://github.com/donaldduck/testrepo","homepage":null,"size":15,"stargazers_count":0,"watchers_count":0,"language":"Ruby","has_issues":true,"has_projects":false,"has_downloads":true,"has_wiki":false,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"open_issues_count":9,"license":null,"forks":0,"open_issues":9,"watchers":0,"default_branch":"master"}},"base":{"label":"donaldduck:master","ref":"master","sha":"05e7bf92117c784e6d17194f1a07c8258bbc8d3a","user":{"login":"donaldduck","id":1234560,"avatar_url":"https://avatars2.githubusercontent.com/u/3505400?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"repo":{"id":123456955,"name":"testrepo","full_name":"donaldduck/testrepo","owner":{"login":"donaldduck","id":1234560,"avatar_url":"https://avatars2.githubusercontent.com/u/3505400?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"private":true,"html_url":"https://github.com/donaldduck/testrepo","description":null,"fork":true,"url":"https://api.github.com/repos/donaldduck/testrepo","forks_url":"https://api.github.com/repos/donaldduck/testrepo/forks","keys_url":"https://api.github.com/repos/donaldduck/testrepo/keys{/key_id}","collaborators_url":"https://api.github.com/repos/donaldduck/testrepo/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/donaldduck/testrepo/teams","hooks_url":"https://api.github.com/repos/donaldduck/testrepo/hooks","issue_events_url":"https://api.github.com/repos/donaldduck/testrepo/issues/events{/number}","events_url":"https://api.github.com/repos/donaldduck/testrepo/events","assignees_url":"https://api.github.com/repos/donaldduck/testrepo/assignees{/user}","branches_url":"https://api.github.com/repos/donaldduck/testrepo/branches{/branch}","tags_url":"https://api.github.com/repos/donaldduck/testrepo/tags","blobs_url":"https://api.github.com/repos/donaldduck/testrepo/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/donaldduck/testrepo/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/donaldduck/testrepo/git/refs{/sha}","trees_url":"https://api.github.com/repos/donaldduck/testrepo/git/trees{/sha}","statuses_url":"https://api.github.com/repos/donaldduck/testrepo/statuses/{sha}","languages_url":"https://api.github.com/repos/donaldduck/testrepo/languages","stargazers_url":"https://api.github.com/repos/donaldduck/testrepo/stargazers","contributors_url":"https://api.github.com/repos/donaldduck/testrepo/contributors","subscribers_url":"https://api.github.com/repos/donaldduck/testrepo/subscribers","subscription_url":"https://api.github.com/repos/donaldduck/testrepo/subscription","commits_url":"https://api.github.com/repos/donaldduck/testrepo/commits{/sha}","git_commits_url":"https://api.github.com/repos/donaldduck/testrepo/git/commits{/sha}","comments_url":"https://api.github.com/repos/donaldduck/testrepo/comments{/number}","issue_comment_url":"https://api.github.com/repos/donaldduck/testrepo/issues/comments{/number}","contents_url":"https://api.github.com/repos/donaldduck/testrepo/contents/{+path}","compare_url":"https://api.github.com/repos/donaldduck/testrepo/compare/{base}...{head}","merges_url":"https://api.github.com/repos/donaldduck/testrepo/merges","archive_url":"https://api.github.com/repos/donaldduck/testrepo/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/donaldduck/testrepo/downloads","issues_url":"https://api.github.com/repos/donaldduck/testrepo/issues{/number}","pulls_url":"https://api.github.com/repos/donaldduck/testrepo/pulls{/number}","milestones_url":"https://api.github.com/repos/donaldduck/testrepo/milestones{/number}","notifications_url":"https://api.github.com/repos/donaldduck/testrepo/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/donaldduck/testrepo/labels{/name}","releases_url":"https://api.github.com/repos/donaldduck/testrepo/releases{/id}","deployments_url":"https://api.github.com/repos/donaldduck/testrepo/deployments","created_at":"2017-12-23T18:58:57Z","updated_at":"2017-12-23T19:00:02Z","pushed_at":"2018-01-25T21:02:19Z","git_url":"git://github.com/donaldduck/testrepo.git","ssh_url":"git@github.com:donaldduck/testrepo.git","clone_url":"https://github.com/donaldduck/testrepo.git","svn_url":"https://github.com/donaldduck/testrepo","homepage":null,"size":15,"stargazers_count":0,"watchers_count":0,"language":"Ruby","has_issues":true,"has_projects":false,"has_downloads":true,"has_wiki":false,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"open_issues_count":9,"license":null,"forks":0,"open_issues":9,"watchers":0,"default_branch":"master"}},"_links":{"self":{"href":"https://api.github.com/repos/donaldduck/testrepo/pulls/29"},"html":{"href":"https://github.com/donaldduck/testrepo/pull/29"},"issue":{"href":"https://api.github.com/repos/donaldduck/testrepo/issues/29"},"comments":{"href":"https://api.github.com/repos/donaldduck/testrepo/issues/29/comments"},"review_comments":{"href":"https://api.github.com/repos/donaldduck/testrepo/pulls/29/comments"},"review_comment":{"href":"https://api.github.com/repos/donaldduck/testrepo/pulls/comments{/number}"},"commits":{"href":"https://api.github.com/repos/donaldduck/testrepo/pulls/29/commits"},"statuses":{"href":"https://api.github.com/repos/donaldduck/testrepo/statuses/16aaf0dedd31dd7646dd1a9fa3cc1d911541bf49"}},"author_association":"COLLABORATOR","merged":false,"mergeable":null,"rebaseable":null,"mergeable_state":"unknown","merged_by":null,"comments":0,"review_comments":0,"maintainer_can_modify":false,"commits":2,"additions":0,"deletions":0,"changed_files":2}'
+      string: ''
     http_version: 
-  recorded_at: Thu, 25 Jan 2018 21:02:21 GMT
+  recorded_at: Mon, 05 Feb 2018 21:26:36 GMT
 - request:
     method: get
     uri: https://api.github.com/user
@@ -102,7 +170,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Thu, 25 Jan 2018 21:02:22 GMT
+      - Mon, 05 Feb 2018 21:26:37 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -112,17 +180,17 @@ http_interactions:
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4969'
+      - '4958'
       X-Ratelimit-Reset:
-      - '1516915084'
+      - '1517867477'
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Vary:
       - Accept, Authorization, Cookie, X-GitHub-OTP
       Etag:
-      - W/ffffffff37a5711fb4b6e55e9deba9da1"
+      - W/"867a7455cae6fa03110405ae3f4f8ffe"
       Last-Modified:
-      - Fri, 19 Jan 2018 08:36:16 GMT
+      - Tue, 30 Jan 2018 20:56:34 GMT
       X-Oauth-Scopes:
       - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
         delete_repo, gist, notifications, repo, user
@@ -146,18 +214,326 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Runtime-Rack:
-      - '0.059561'
+      - '0.053801'
       X-Github-Request-Id:
-      - 86F6:1DEA:16C56AA:FF6F0FF:5A6A45DD
+      - B02E:14EB:257646D:527D9E8:5A78CC0D
     body:
       encoding: ASCII-8BIT
-      string: '{"login":"donaldduck","id":1234560,"avatar_url":"https://avatars2.githubusercontent.com/u/3505400?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false,"name":"Donald
-        Duck","company":"@mickeymouselaws","blog":"","location":"Berlin","email":"donald.pub2@gmail.com","hireable":true,"bio":null,"public_repos":16,"public_gists":0,"followers":9,"following":0,"created_at":"2012-04-01T11:52:16Z","updated_at":"2018-01-19T08:36:16Z","private_gists":0,"total_private_repos":1,"owned_private_repos":0,"disk_usage":32519,"collaborators":0,"two_factor_authentication":true,"plan":{"name":"free","space":976562499,"collaborators":0,"private_repos":0}}'
+      string: '{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false,"name":"Donald
+        Duck","company":"@momcorp","blog":"","location":"Berlin","email":"donald.pub2@gmail.com","hireable":true,"bio":null,"public_repos":19,"public_gists":0,"followers":9,"following":0,"created_at":"2012-04-01T11:52:16Z","updated_at":"2018-01-30T20:56:34Z","private_gists":0,"total_private_repos":0,"owned_private_repos":0,"disk_usage":32597,"collaborators":0,"two_factor_authentication":true,"plan":{"name":"free","space":976562499,"collaborators":0,"private_repos":0}}'
     http_version: 
-  recorded_at: Thu, 25 Jan 2018 21:02:22 GMT
+  recorded_at: Mon, 05 Feb 2018 21:26:37 GMT
+- request:
+    method: get
+    uri: https://api.github.com/user
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Ruby
+      Host:
+      - api.github.com
+      Authorization:
+      - Basic <GITHUB_CREDENTIALS>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Mon, 05 Feb 2018 21:26:38 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4957'
+      X-Ratelimit-Reset:
+      - '1517867477'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      Etag:
+      - W/"867a7455cae6fa03110405ae3f4f8ffe"
+      Last-Modified:
+      - Tue, 30 Jan 2018 20:56:34 GMT
+      X-Oauth-Scopes:
+      - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
+        delete_repo, gist, notifications, repo, user
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - default-src 'none'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Runtime-Rack:
+      - '0.048911'
+      X-Github-Request-Id:
+      - E5F0:14EE:3738529:85666B4:5A78CC0E
+    body:
+      encoding: ASCII-8BIT
+      string: '{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false,"name":"Donald
+        Duck","company":"@momcorp","blog":"","location":"Berlin","email":"donald.pub2@gmail.com","hireable":true,"bio":null,"public_repos":19,"public_gists":0,"followers":9,"following":0,"created_at":"2012-04-01T11:52:16Z","updated_at":"2018-01-30T20:56:34Z","private_gists":0,"total_private_repos":0,"owned_private_repos":0,"disk_usage":32597,"collaborators":0,"two_factor_authentication":true,"plan":{"name":"free","space":976562499,"collaborators":0,"private_repos":0}}'
+    http_version: 
+  recorded_at: Mon, 05 Feb 2018 21:26:38 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/donaldduck/testrepo_f/collaborators/donaldduck/permission
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Ruby
+      Host:
+      - api.github.com
+      Authorization:
+      - Basic <GITHUB_CREDENTIALS>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Mon, 05 Feb 2018 21:26:39 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4956'
+      X-Ratelimit-Reset:
+      - '1517867477'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      Etag:
+      - W/"2e0eb2906871bf26051feba70dcc7ce1"
+      X-Oauth-Scopes:
+      - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
+        delete_repo, gist, notifications, repo, user
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - default-src 'none'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Runtime-Rack:
+      - '0.038288'
+      X-Github-Request-Id:
+      - E5F2:14EE:3738588:8566787:5A78CC0E
+    body:
+      encoding: ASCII-8BIT
+      string: '{"permission":"admin","user":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false}}'
+    http_version: 
+  recorded_at: Mon, 05 Feb 2018 21:26:39 GMT
 - request:
     method: post
-    uri: https://api.github.com/repos/donaldduck/testrepo/issues/29/assignees
+    uri: https://api.github.com/repos/donaldduck/testrepo_f/pulls
+    body:
+      encoding: UTF-8
+      string: '{"title":"Title","body":"Description","head":"mybranch","base":"master"}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Ruby
+      Host:
+      - api.github.com
+      Authorization:
+      - Basic <GITHUB_CREDENTIALS>
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Mon, 05 Feb 2018 21:26:44 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '15314'
+      Status:
+      - 201 Created
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4955'
+      X-Ratelimit-Reset:
+      - '1517867477'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      Etag:
+      - '"4f1d03362198907ea99a68189d4323b9"'
+      X-Oauth-Scopes:
+      - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
+        delete_repo, gist, notifications, repo, user
+      X-Accepted-Oauth-Scopes:
+      - ''
+      Location:
+      - https://api.github.com/repos/donaldduck/testrepo_f/pulls/2
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - default-src 'none'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Runtime-Rack:
+      - '0.393093'
+      X-Github-Request-Id:
+      - E5F8:14EB:257664F:527DDD0:5A78CC14
+    body:
+      encoding: UTF-8
+      string: '{"url":"https://api.github.com/repos/donaldduck/testrepo_f/pulls/2","id":123456860,"html_url":"https://github.com/donaldduck/testrepo_f/pull/2","diff_url":"https://github.com/donaldduck/testrepo_f/pull/2.diff","patch_url":"https://github.com/donaldduck/testrepo_f/pull/2.patch","issue_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/2","number":2,"state":"open","locked":false,"title":"Title","user":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"body":"Description","created_at":"2018-02-05T21:26:44Z","updated_at":"2018-02-05T21:26:44Z","closed_at":null,"merged_at":null,"merge_commit_sha":null,"assignee":null,"assignees":[],"requested_reviewers":[],"requested_teams":[],"milestone":null,"commits_url":"https://api.github.com/repos/donaldduck/testrepo_f/pulls/2/commits","review_comments_url":"https://api.github.com/repos/donaldduck/testrepo_f/pulls/2/comments","review_comment_url":"https://api.github.com/repos/donaldduck/testrepo_f/pulls/comments{/number}","comments_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/2/comments","statuses_url":"https://api.github.com/repos/donaldduck/testrepo_f/statuses/2ed302a6c2b3bbfab51c64321b20b854017b97ee","head":{"label":"donaldduck:mybranch","ref":"mybranch","sha":"2ed302a6c2b3bbfab51c64321b20b854017b97ee","user":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"repo":{"id":123456502,"name":"testrepo_f","full_name":"donaldduck/testrepo_f","owner":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"private":false,"html_url":"https://github.com/donaldduck/testrepo_f","description":null,"fork":true,"url":"https://api.github.com/repos/donaldduck/testrepo_f","forks_url":"https://api.github.com/repos/donaldduck/testrepo_f/forks","keys_url":"https://api.github.com/repos/donaldduck/testrepo_f/keys{/key_id}","collaborators_url":"https://api.github.com/repos/donaldduck/testrepo_f/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/donaldduck/testrepo_f/teams","hooks_url":"https://api.github.com/repos/donaldduck/testrepo_f/hooks","issue_events_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/events{/number}","events_url":"https://api.github.com/repos/donaldduck/testrepo_f/events","assignees_url":"https://api.github.com/repos/donaldduck/testrepo_f/assignees{/user}","branches_url":"https://api.github.com/repos/donaldduck/testrepo_f/branches{/branch}","tags_url":"https://api.github.com/repos/donaldduck/testrepo_f/tags","blobs_url":"https://api.github.com/repos/donaldduck/testrepo_f/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/donaldduck/testrepo_f/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/donaldduck/testrepo_f/git/refs{/sha}","trees_url":"https://api.github.com/repos/donaldduck/testrepo_f/git/trees{/sha}","statuses_url":"https://api.github.com/repos/donaldduck/testrepo_f/statuses/{sha}","languages_url":"https://api.github.com/repos/donaldduck/testrepo_f/languages","stargazers_url":"https://api.github.com/repos/donaldduck/testrepo_f/stargazers","contributors_url":"https://api.github.com/repos/donaldduck/testrepo_f/contributors","subscribers_url":"https://api.github.com/repos/donaldduck/testrepo_f/subscribers","subscription_url":"https://api.github.com/repos/donaldduck/testrepo_f/subscription","commits_url":"https://api.github.com/repos/donaldduck/testrepo_f/commits{/sha}","git_commits_url":"https://api.github.com/repos/donaldduck/testrepo_f/git/commits{/sha}","comments_url":"https://api.github.com/repos/donaldduck/testrepo_f/comments{/number}","issue_comment_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/comments{/number}","contents_url":"https://api.github.com/repos/donaldduck/testrepo_f/contents/{+path}","compare_url":"https://api.github.com/repos/donaldduck/testrepo_f/compare/{base}...{head}","merges_url":"https://api.github.com/repos/donaldduck/testrepo_f/merges","archive_url":"https://api.github.com/repos/donaldduck/testrepo_f/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/donaldduck/testrepo_f/downloads","issues_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues{/number}","pulls_url":"https://api.github.com/repos/donaldduck/testrepo_f/pulls{/number}","milestones_url":"https://api.github.com/repos/donaldduck/testrepo_f/milestones{/number}","notifications_url":"https://api.github.com/repos/donaldduck/testrepo_f/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/donaldduck/testrepo_f/labels{/name}","releases_url":"https://api.github.com/repos/donaldduck/testrepo_f/releases{/id}","deployments_url":"https://api.github.com/repos/donaldduck/testrepo_f/deployments","created_at":"2018-02-05T20:44:53Z","updated_at":"2018-02-05T21:04:59Z","pushed_at":"2018-02-05T21:26:43Z","git_url":"git://github.com/donaldduck/testrepo_f.git","ssh_url":"git@github.com:donaldduck/testrepo_f.git","clone_url":"https://github.com/donaldduck/testrepo_f.git","svn_url":"https://github.com/donaldduck/testrepo_f","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":false,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"open_issues_count":1,"license":null,"forks":0,"open_issues":1,"watchers":0,"default_branch":"master"}},"base":{"label":"donaldduck:master","ref":"master","sha":"c971bf0ec8076e78b866a41ba4c3a83bc6a4be73","user":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"repo":{"id":123456502,"name":"testrepo_f","full_name":"donaldduck/testrepo_f","owner":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"private":false,"html_url":"https://github.com/donaldduck/testrepo_f","description":null,"fork":true,"url":"https://api.github.com/repos/donaldduck/testrepo_f","forks_url":"https://api.github.com/repos/donaldduck/testrepo_f/forks","keys_url":"https://api.github.com/repos/donaldduck/testrepo_f/keys{/key_id}","collaborators_url":"https://api.github.com/repos/donaldduck/testrepo_f/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/donaldduck/testrepo_f/teams","hooks_url":"https://api.github.com/repos/donaldduck/testrepo_f/hooks","issue_events_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/events{/number}","events_url":"https://api.github.com/repos/donaldduck/testrepo_f/events","assignees_url":"https://api.github.com/repos/donaldduck/testrepo_f/assignees{/user}","branches_url":"https://api.github.com/repos/donaldduck/testrepo_f/branches{/branch}","tags_url":"https://api.github.com/repos/donaldduck/testrepo_f/tags","blobs_url":"https://api.github.com/repos/donaldduck/testrepo_f/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/donaldduck/testrepo_f/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/donaldduck/testrepo_f/git/refs{/sha}","trees_url":"https://api.github.com/repos/donaldduck/testrepo_f/git/trees{/sha}","statuses_url":"https://api.github.com/repos/donaldduck/testrepo_f/statuses/{sha}","languages_url":"https://api.github.com/repos/donaldduck/testrepo_f/languages","stargazers_url":"https://api.github.com/repos/donaldduck/testrepo_f/stargazers","contributors_url":"https://api.github.com/repos/donaldduck/testrepo_f/contributors","subscribers_url":"https://api.github.com/repos/donaldduck/testrepo_f/subscribers","subscription_url":"https://api.github.com/repos/donaldduck/testrepo_f/subscription","commits_url":"https://api.github.com/repos/donaldduck/testrepo_f/commits{/sha}","git_commits_url":"https://api.github.com/repos/donaldduck/testrepo_f/git/commits{/sha}","comments_url":"https://api.github.com/repos/donaldduck/testrepo_f/comments{/number}","issue_comment_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/comments{/number}","contents_url":"https://api.github.com/repos/donaldduck/testrepo_f/contents/{+path}","compare_url":"https://api.github.com/repos/donaldduck/testrepo_f/compare/{base}...{head}","merges_url":"https://api.github.com/repos/donaldduck/testrepo_f/merges","archive_url":"https://api.github.com/repos/donaldduck/testrepo_f/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/donaldduck/testrepo_f/downloads","issues_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues{/number}","pulls_url":"https://api.github.com/repos/donaldduck/testrepo_f/pulls{/number}","milestones_url":"https://api.github.com/repos/donaldduck/testrepo_f/milestones{/number}","notifications_url":"https://api.github.com/repos/donaldduck/testrepo_f/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/donaldduck/testrepo_f/labels{/name}","releases_url":"https://api.github.com/repos/donaldduck/testrepo_f/releases{/id}","deployments_url":"https://api.github.com/repos/donaldduck/testrepo_f/deployments","created_at":"2018-02-05T20:44:53Z","updated_at":"2018-02-05T21:04:59Z","pushed_at":"2018-02-05T21:26:43Z","git_url":"git://github.com/donaldduck/testrepo_f.git","ssh_url":"git@github.com:donaldduck/testrepo_f.git","clone_url":"https://github.com/donaldduck/testrepo_f.git","svn_url":"https://github.com/donaldduck/testrepo_f","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":false,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"open_issues_count":1,"license":null,"forks":0,"open_issues":1,"watchers":0,"default_branch":"master"}},"_links":{"self":{"href":"https://api.github.com/repos/donaldduck/testrepo_f/pulls/2"},"html":{"href":"https://github.com/donaldduck/testrepo_f/pull/2"},"issue":{"href":"https://api.github.com/repos/donaldduck/testrepo_f/issues/2"},"comments":{"href":"https://api.github.com/repos/donaldduck/testrepo_f/issues/2/comments"},"review_comments":{"href":"https://api.github.com/repos/donaldduck/testrepo_f/pulls/2/comments"},"review_comment":{"href":"https://api.github.com/repos/donaldduck/testrepo_f/pulls/comments{/number}"},"commits":{"href":"https://api.github.com/repos/donaldduck/testrepo_f/pulls/2/commits"},"statuses":{"href":"https://api.github.com/repos/donaldduck/testrepo_f/statuses/2ed302a6c2b3bbfab51c64321b20b854017b97ee"}},"author_association":"OWNER","merged":false,"mergeable":null,"rebaseable":null,"mergeable_state":"unknown","merged_by":null,"comments":0,"review_comments":0,"maintainer_can_modify":false,"commits":1,"additions":0,"deletions":0,"changed_files":1}'
+    http_version: 
+  recorded_at: Mon, 05 Feb 2018 21:26:45 GMT
+- request:
+    method: get
+    uri: https://api.github.com/user
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Ruby
+      Host:
+      - api.github.com
+      Authorization:
+      - Basic <GITHUB_CREDENTIALS>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Mon, 05 Feb 2018 21:26:46 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4954'
+      X-Ratelimit-Reset:
+      - '1517867477'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      Etag:
+      - W/"867a7455cae6fa03110405ae3f4f8ffe"
+      Last-Modified:
+      - Tue, 30 Jan 2018 20:56:34 GMT
+      X-Oauth-Scopes:
+      - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
+        delete_repo, gist, notifications, repo, user
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - default-src 'none'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Runtime-Rack:
+      - '0.042895'
+      X-Github-Request-Id:
+      - B03C:14EB:25766BD:527DEC2:5A78CC15
+    body:
+      encoding: ASCII-8BIT
+      string: '{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false,"name":"Donald
+        Duck","company":"@momcorp","blog":"","location":"Berlin","email":"donald.pub2@gmail.com","hireable":true,"bio":null,"public_repos":19,"public_gists":0,"followers":9,"following":0,"created_at":"2012-04-01T11:52:16Z","updated_at":"2018-01-30T20:56:34Z","private_gists":0,"total_private_repos":0,"owned_private_repos":0,"disk_usage":32597,"collaborators":0,"two_factor_authentication":true,"plan":{"name":"free","space":976562499,"collaborators":0,"private_repos":0}}'
+    http_version: 
+  recorded_at: Mon, 05 Feb 2018 21:26:46 GMT
+- request:
+    method: post
+    uri: https://api.github.com/repos/donaldduck/testrepo_f/issues/2/assignees
     body:
       encoding: UTF-8
       string: '{"assignees":["donaldduck"]}'
@@ -180,32 +556,32 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Thu, 25 Jan 2018 21:02:23 GMT
+      - Mon, 05 Feb 2018 21:26:47 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '3926'
+      - '3899'
       Status:
       - 201 Created
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4968'
+      - '4953'
       X-Ratelimit-Reset:
-      - '1516915084'
+      - '1517867477'
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Vary:
       - Accept, Authorization, Cookie, X-GitHub-OTP
       Etag:
-      - '"ffffffff1a75e84e8bd253faf3d2efb0"'
+      - '"0b93726fe5cf195c61d5387dc6322b91"'
       X-Oauth-Scopes:
       - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
         delete_repo, gist, notifications, repo, user
       X-Accepted-Oauth-Scopes:
       - ''
       Location:
-      - https://api.github.com/repos/donaldduck/testrepo/issues/29
+      - https://api.github.com/repos/donaldduck/testrepo_f/issues/2
       X-Github-Media-Type:
       - github.v3; format=json
       Access-Control-Expose-Headers:
@@ -224,12 +600,12 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Runtime-Rack:
-      - '0.183049'
+      - '0.215577'
       X-Github-Request-Id:
-      - 86F8:1DED:1A195AF:FFFFFFF:5A6A45DE
+      - B040:14EB:2576701:527DF5A:5A78CC16
     body:
       encoding: UTF-8
-      string: '{"url":"https://api.github.com/repos/donaldduck/testrepo/issues/29","repository_url":"https://api.github.com/repos/donaldduck/testrepo","labels_url":"https://api.github.com/repos/donaldduck/testrepo/issues/29/labels{/name}","comments_url":"https://api.github.com/repos/donaldduck/testrepo/issues/29/comments","events_url":"https://api.github.com/repos/donaldduck/testrepo/issues/29/events","html_url":"https://github.com/donaldduck/testrepo/pull/29","id":123456597,"number":29,"title":"Title","user":{"login":"donaldduck","id":1234560,"avatar_url":"https://avatars2.githubusercontent.com/u/3505400?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"labels":[],"state":"open","locked":false,"assignee":{"login":"donaldduck","id":1234560,"avatar_url":"https://avatars2.githubusercontent.com/u/3505400?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"assignees":[{"login":"donaldduck","id":1234560,"avatar_url":"https://avatars2.githubusercontent.com/u/3505400?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false}],"milestone":null,"comments":0,"created_at":"2018-01-25T21:02:20Z","updated_at":"2018-01-25T21:02:23Z","closed_at":null,"author_association":"COLLABORATOR","pull_request":{"url":"https://api.github.com/repos/donaldduck/testrepo/pulls/29","html_url":"https://github.com/donaldduck/testrepo/pull/29","diff_url":"https://github.com/donaldduck/testrepo/pull/29.diff","patch_url":"https://github.com/donaldduck/testrepo/pull/29.patch"},"body":"Description"}'
+      string: '{"url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/2","repository_url":"https://api.github.com/repos/donaldduck/testrepo_f","labels_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/2/labels{/name}","comments_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/2/comments","events_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/2/events","html_url":"https://github.com/donaldduck/testrepo_f/pull/2","id":123456865,"number":2,"title":"Title","user":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"labels":[],"state":"open","locked":false,"assignee":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"assignees":[{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false}],"milestone":null,"comments":0,"created_at":"2018-02-05T21:26:44Z","updated_at":"2018-02-05T21:26:47Z","closed_at":null,"author_association":"OWNER","pull_request":{"url":"https://api.github.com/repos/donaldduck/testrepo_f/pulls/2","html_url":"https://github.com/donaldduck/testrepo_f/pull/2","diff_url":"https://github.com/donaldduck/testrepo_f/pull/2.diff","patch_url":"https://github.com/donaldduck/testrepo_f/pull/2.patch"},"body":"Description"}'
     http_version: 
-  recorded_at: Thu, 25 Jan 2018 21:02:23 GMT
+  recorded_at: Mon, 05 Feb 2018 21:26:47 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/create_pr_upstream.yml
+++ b/spec/vcr_cassettes/create_pr_upstream.yml
@@ -25,7 +25,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Tue, 21 Nov 2017 09:42:47 GMT
+      - Mon, 05 Feb 2018 21:10:32 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -35,17 +35,17 @@ http_interactions:
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4990'
+      - '4975'
       X-Ratelimit-Reset:
-      - '1511259603'
+      - '1517867477'
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Vary:
       - Accept, Authorization, Cookie, X-GitHub-OTP
       Etag:
-      - W/"194f0cc0672e8b48c10eea188788c6b8"
+      - W/"867a7455cae6fa03110405ae3f4f8ffe"
       Last-Modified:
-      - Mon, 20 Nov 2017 21:53:27 GMT
+      - Tue, 30 Jan 2018 20:56:34 GMT
       X-Oauth-Scopes:
       - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
         delete_repo, gist, notifications, repo, user
@@ -69,21 +69,21 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Runtime-Rack:
-      - '0.057428'
+      - '0.050954'
       X-Github-Request-Id:
-      - B096:62B8:24202A:5A16B5:5A13F516
+      - AF56:14EB:256491C:52561AE:5A78C847
     body:
       encoding: ASCII-8BIT
       string: '{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false,"name":"Donald
-        Duck","company":"@mickeymouselaws","blog":"","location":"Duckburg","email":"donald.pub2@gmail.com","hireable":true,"bio":null,"public_repos":13,"public_gists":0,"followers":7,"following":0,"created_at":"2012-04-01T11:52:16Z","updated_at":"2017-11-20T21:53:27Z","private_gists":0,"total_private_repos":1,"owned_private_repos":0,"disk_usage":32253,"collaborators":0,"two_factor_authentication":true,"plan":{"name":"free","space":976562499,"collaborators":0,"private_repos":0}}'
+        Duck","company":"@momcorp","blog":"","location":"Berlin","email":"donald.pub2@gmail.com","hireable":true,"bio":null,"public_repos":19,"public_gists":0,"followers":9,"following":0,"created_at":"2012-04-01T11:52:16Z","updated_at":"2018-01-30T20:56:34Z","private_gists":0,"total_private_repos":0,"owned_private_repos":0,"disk_usage":32597,"collaborators":0,"two_factor_authentication":true,"plan":{"name":"free","space":976562499,"collaborators":0,"private_repos":0}}'
     http_version: 
-  recorded_at: Tue, 21 Nov 2017 09:42:47 GMT
+  recorded_at: Mon, 05 Feb 2018 21:10:32 GMT
 - request:
-    method: post
-    uri: https://api.github.com/repos/donald-fr/testrepo_u/pulls
+    method: get
+    uri: https://api.github.com/repos/donald-fr/testrepo_u/collaborators/donaldduck
     body:
-      encoding: UTF-8
-      string: '{"title":"Title","body":"Description","head":"donaldduck:mybranch","base":"master"}'
+      encoding: US-ASCII
+      string: ''
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -97,38 +97,28 @@ http_interactions:
       - Basic <GITHUB_CREDENTIALS>
   response:
     status:
-      code: 201
-      message: Created
+      code: 204
+      message: No Content
     headers:
       Server:
       - GitHub.com
       Date:
-      - Tue, 21 Nov 2017 09:42:48 GMT
+      - Mon, 05 Feb 2018 21:10:33 GMT
       Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '14973'
+      - application/octet-stream
       Status:
-      - 201 Created
+      - 204 No Content
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4989'
+      - '4974'
       X-Ratelimit-Reset:
-      - '1511259603'
-      Cache-Control:
-      - private, max-age=60, s-maxage=60
-      Vary:
-      - Accept, Authorization, Cookie, X-GitHub-OTP
-      Etag:
-      - '"250fb22bf517ebb6128e0a03fb124f37"'
+      - '1517867477'
       X-Oauth-Scopes:
       - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
         delete_repo, gist, notifications, repo, user
       X-Accepted-Oauth-Scopes:
       - ''
-      Location:
-      - https://api.github.com/repos/donald-fr/testrepo_u/pulls/4
       X-Github-Media-Type:
       - github.v3; format=json
       Access-Control-Expose-Headers:
@@ -147,14 +137,14 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Runtime-Rack:
-      - '0.511022'
+      - '0.041486'
       X-Github-Request-Id:
-      - AA48:62B1:273FE0:514A96:5A13F517
+      - AF5A:14EC:2F985BC:65E531B:5A78C848
     body:
       encoding: UTF-8
-      string: '{"url":"https://api.github.com/repos/donald-fr/testrepo_u/pulls/4","id":123456017,"html_url":"https://github.com/donald-fr/testrepo_u/pull/4","diff_url":"https://github.com/donald-fr/testrepo_u/pull/4.diff","patch_url":"https://github.com/donald-fr/testrepo_u/pull/4.patch","issue_url":"https://api.github.com/repos/donald-fr/testrepo_u/issues/4","number":4,"state":"open","locked":false,"title":"Title","user":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"body":"Description","created_at":"2017-11-21T09:42:48Z","updated_at":"2017-11-21T09:42:48Z","closed_at":null,"merged_at":null,"merge_commit_sha":null,"assignee":null,"assignees":[],"requested_reviewers":[],"milestone":null,"commits_url":"https://api.github.com/repos/donald-fr/testrepo_u/pulls/4/commits","review_comments_url":"https://api.github.com/repos/donald-fr/testrepo_u/pulls/4/comments","review_comment_url":"https://api.github.com/repos/donald-fr/testrepo_u/pulls/comments{/number}","comments_url":"https://api.github.com/repos/donald-fr/testrepo_u/issues/4/comments","statuses_url":"https://api.github.com/repos/donald-fr/testrepo_u/statuses/d64cdf61ac74cb104d5b423a9c6c7a2ef5678b27","head":{"label":"donaldduck:mybranch","ref":"mybranch","sha":"d64cdf61ac74cb104d5b423a9c6c7a2ef5678b27","user":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"repo":{"id":123456177,"name":"testrepo_2f","full_name":"donaldduck/testrepo_2f","owner":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"private":false,"html_url":"https://github.com/donaldduck/testrepo_2f","description":null,"fork":true,"url":"https://api.github.com/repos/donaldduck/testrepo_2f","forks_url":"https://api.github.com/repos/donaldduck/testrepo_2f/forks","keys_url":"https://api.github.com/repos/donaldduck/testrepo_2f/keys{/key_id}","collaborators_url":"https://api.github.com/repos/donaldduck/testrepo_2f/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/donaldduck/testrepo_2f/teams","hooks_url":"https://api.github.com/repos/donaldduck/testrepo_2f/hooks","issue_events_url":"https://api.github.com/repos/donaldduck/testrepo_2f/issues/events{/number}","events_url":"https://api.github.com/repos/donaldduck/testrepo_2f/events","assignees_url":"https://api.github.com/repos/donaldduck/testrepo_2f/assignees{/user}","branches_url":"https://api.github.com/repos/donaldduck/testrepo_2f/branches{/branch}","tags_url":"https://api.github.com/repos/donaldduck/testrepo_2f/tags","blobs_url":"https://api.github.com/repos/donaldduck/testrepo_2f/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/donaldduck/testrepo_2f/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/donaldduck/testrepo_2f/git/refs{/sha}","trees_url":"https://api.github.com/repos/donaldduck/testrepo_2f/git/trees{/sha}","statuses_url":"https://api.github.com/repos/donaldduck/testrepo_2f/statuses/{sha}","languages_url":"https://api.github.com/repos/donaldduck/testrepo_2f/languages","stargazers_url":"https://api.github.com/repos/donaldduck/testrepo_2f/stargazers","contributors_url":"https://api.github.com/repos/donaldduck/testrepo_2f/contributors","subscribers_url":"https://api.github.com/repos/donaldduck/testrepo_2f/subscribers","subscription_url":"https://api.github.com/repos/donaldduck/testrepo_2f/subscription","commits_url":"https://api.github.com/repos/donaldduck/testrepo_2f/commits{/sha}","git_commits_url":"https://api.github.com/repos/donaldduck/testrepo_2f/git/commits{/sha}","comments_url":"https://api.github.com/repos/donaldduck/testrepo_2f/comments{/number}","issue_comment_url":"https://api.github.com/repos/donaldduck/testrepo_2f/issues/comments{/number}","contents_url":"https://api.github.com/repos/donaldduck/testrepo_2f/contents/{+path}","compare_url":"https://api.github.com/repos/donaldduck/testrepo_2f/compare/{base}...{head}","merges_url":"https://api.github.com/repos/donaldduck/testrepo_2f/merges","archive_url":"https://api.github.com/repos/donaldduck/testrepo_2f/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/donaldduck/testrepo_2f/downloads","issues_url":"https://api.github.com/repos/donaldduck/testrepo_2f/issues{/number}","pulls_url":"https://api.github.com/repos/donaldduck/testrepo_2f/pulls{/number}","milestones_url":"https://api.github.com/repos/donaldduck/testrepo_2f/milestones{/number}","notifications_url":"https://api.github.com/repos/donaldduck/testrepo_2f/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/donaldduck/testrepo_2f/labels{/name}","releases_url":"https://api.github.com/repos/donaldduck/testrepo_2f/releases{/id}","deployments_url":"https://api.github.com/repos/donaldduck/testrepo_2f/deployments","created_at":"2017-11-21T09:26:50Z","updated_at":"2017-11-21T09:27:23Z","pushed_at":"2017-11-21T09:40:19Z","git_url":"git://github.com/donaldduck/testrepo_2f.git","ssh_url":"git@github.com:donaldduck/testrepo_2f.git","clone_url":"https://github.com/donaldduck/testrepo_2f.git","svn_url":"https://github.com/donaldduck/testrepo_2f","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":false,"has_downloads":true,"has_wiki":false,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"open_issues_count":0,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master"}},"base":{"label":"donald-fr:master","ref":"master","sha":"6ec60827e3f235b44126b87c099054b060249b99","user":{"login":"donald-fr","id":12345612,"avatar_url":"https://avatars2.githubusercontent.com/u/33847412?v=4","gravatar_id":"","url":"https://api.github.com/users/donald-fr","html_url":"https://github.com/donald-fr","followers_url":"https://api.github.com/users/donald-fr/followers","following_url":"https://api.github.com/users/donald-fr/following{/other_user}","gists_url":"https://api.github.com/users/donald-fr/gists{/gist_id}","starred_url":"https://api.github.com/users/donald-fr/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donald-fr/subscriptions","organizations_url":"https://api.github.com/users/donald-fr/orgs","repos_url":"https://api.github.com/users/donald-fr/repos","events_url":"https://api.github.com/users/donald-fr/events{/privacy}","received_events_url":"https://api.github.com/users/donald-fr/received_events","type":"User","site_admin":false},"repo":{"id":123456004,"name":"testrepo_u","full_name":"donald-fr/testrepo_u","owner":{"login":"donald-fr","id":12345612,"avatar_url":"https://avatars2.githubusercontent.com/u/33847412?v=4","gravatar_id":"","url":"https://api.github.com/users/donald-fr","html_url":"https://github.com/donald-fr","followers_url":"https://api.github.com/users/donald-fr/followers","following_url":"https://api.github.com/users/donald-fr/following{/other_user}","gists_url":"https://api.github.com/users/donald-fr/gists{/gist_id}","starred_url":"https://api.github.com/users/donald-fr/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donald-fr/subscriptions","organizations_url":"https://api.github.com/users/donald-fr/orgs","repos_url":"https://api.github.com/users/donald-fr/repos","events_url":"https://api.github.com/users/donald-fr/events{/privacy}","received_events_url":"https://api.github.com/users/donald-fr/received_events","type":"User","site_admin":false},"private":false,"html_url":"https://github.com/donald-fr/testrepo_u","description":null,"fork":false,"url":"https://api.github.com/repos/donald-fr/testrepo_u","forks_url":"https://api.github.com/repos/donald-fr/testrepo_u/forks","keys_url":"https://api.github.com/repos/donald-fr/testrepo_u/keys{/key_id}","collaborators_url":"https://api.github.com/repos/donald-fr/testrepo_u/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/donald-fr/testrepo_u/teams","hooks_url":"https://api.github.com/repos/donald-fr/testrepo_u/hooks","issue_events_url":"https://api.github.com/repos/donald-fr/testrepo_u/issues/events{/number}","events_url":"https://api.github.com/repos/donald-fr/testrepo_u/events","assignees_url":"https://api.github.com/repos/donald-fr/testrepo_u/assignees{/user}","branches_url":"https://api.github.com/repos/donald-fr/testrepo_u/branches{/branch}","tags_url":"https://api.github.com/repos/donald-fr/testrepo_u/tags","blobs_url":"https://api.github.com/repos/donald-fr/testrepo_u/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/donald-fr/testrepo_u/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/donald-fr/testrepo_u/git/refs{/sha}","trees_url":"https://api.github.com/repos/donald-fr/testrepo_u/git/trees{/sha}","statuses_url":"https://api.github.com/repos/donald-fr/testrepo_u/statuses/{sha}","languages_url":"https://api.github.com/repos/donald-fr/testrepo_u/languages","stargazers_url":"https://api.github.com/repos/donald-fr/testrepo_u/stargazers","contributors_url":"https://api.github.com/repos/donald-fr/testrepo_u/contributors","subscribers_url":"https://api.github.com/repos/donald-fr/testrepo_u/subscribers","subscription_url":"https://api.github.com/repos/donald-fr/testrepo_u/subscription","commits_url":"https://api.github.com/repos/donald-fr/testrepo_u/commits{/sha}","git_commits_url":"https://api.github.com/repos/donald-fr/testrepo_u/git/commits{/sha}","comments_url":"https://api.github.com/repos/donald-fr/testrepo_u/comments{/number}","issue_comment_url":"https://api.github.com/repos/donald-fr/testrepo_u/issues/comments{/number}","contents_url":"https://api.github.com/repos/donald-fr/testrepo_u/contents/{+path}","compare_url":"https://api.github.com/repos/donald-fr/testrepo_u/compare/{base}...{head}","merges_url":"https://api.github.com/repos/donald-fr/testrepo_u/merges","archive_url":"https://api.github.com/repos/donald-fr/testrepo_u/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/donald-fr/testrepo_u/downloads","issues_url":"https://api.github.com/repos/donald-fr/testrepo_u/issues{/number}","pulls_url":"https://api.github.com/repos/donald-fr/testrepo_u/pulls{/number}","milestones_url":"https://api.github.com/repos/donald-fr/testrepo_u/milestones{/number}","notifications_url":"https://api.github.com/repos/donald-fr/testrepo_u/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/donald-fr/testrepo_u/labels{/name}","releases_url":"https://api.github.com/repos/donald-fr/testrepo_u/releases{/id}","deployments_url":"https://api.github.com/repos/donald-fr/testrepo_u/deployments","created_at":"2017-11-21T09:16:55Z","updated_at":"2017-11-21T09:16:55Z","pushed_at":"2017-11-21T09:41:15Z","git_url":"git://github.com/donald-fr/testrepo_u.git","ssh_url":"git@github.com:donald-fr/testrepo_u.git","clone_url":"https://github.com/donald-fr/testrepo_u.git","svn_url":"https://github.com/donald-fr/testrepo_u","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":1,"mirror_url":null,"archived":false,"open_issues_count":3,"forks":1,"open_issues":3,"watchers":0,"default_branch":"master"}},"_links":{"self":{"href":"https://api.github.com/repos/donald-fr/testrepo_u/pulls/4"},"html":{"href":"https://github.com/donald-fr/testrepo_u/pull/4"},"issue":{"href":"https://api.github.com/repos/donald-fr/testrepo_u/issues/4"},"comments":{"href":"https://api.github.com/repos/donald-fr/testrepo_u/issues/4/comments"},"review_comments":{"href":"https://api.github.com/repos/donald-fr/testrepo_u/pulls/4/comments"},"review_comment":{"href":"https://api.github.com/repos/donald-fr/testrepo_u/pulls/comments{/number}"},"commits":{"href":"https://api.github.com/repos/donald-fr/testrepo_u/pulls/4/commits"},"statuses":{"href":"https://api.github.com/repos/donald-fr/testrepo_u/statuses/d64cdf61ac74cb104d5b423a9c6c7a2ef5678b27"}},"author_association":"CONTRIBUTOR","merged":false,"mergeable":null,"rebaseable":null,"mergeable_state":"unknown","merged_by":null,"comments":0,"review_comments":0,"maintainer_can_modify":true,"commits":1,"additions":0,"deletions":0,"changed_files":0}'
+      string: ''
     http_version: 
-  recorded_at: Tue, 21 Nov 2017 09:42:48 GMT
+  recorded_at: Mon, 05 Feb 2018 21:10:33 GMT
 - request:
     method: get
     uri: https://api.github.com/user
@@ -180,7 +170,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Tue, 21 Nov 2017 09:42:49 GMT
+      - Mon, 05 Feb 2018 21:10:35 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -190,17 +180,17 @@ http_interactions:
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4988'
+      - '4973'
       X-Ratelimit-Reset:
-      - '1511259603'
+      - '1517867477'
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Vary:
       - Accept, Authorization, Cookie, X-GitHub-OTP
       Etag:
-      - W/"194f0cc0672e8b48c10eea188788c6b8"
+      - W/"867a7455cae6fa03110405ae3f4f8ffe"
       Last-Modified:
-      - Mon, 20 Nov 2017 21:53:27 GMT
+      - Tue, 30 Jan 2018 20:56:34 GMT
       X-Oauth-Scopes:
       - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
         delete_repo, gist, notifications, repo, user
@@ -224,18 +214,404 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Runtime-Rack:
-      - '0.047289'
+      - '0.055897'
       X-Github-Request-Id:
-      - B09A:62B1:274093:514BE1:5A13F519
+      - E51A:14EE:371ECBC:852BFA3:5A78C84A
     body:
       encoding: ASCII-8BIT
       string: '{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false,"name":"Donald
-        Duck","company":"@mickeymouselaws","blog":"","location":"Duckburg","email":"donald.pub2@gmail.com","hireable":true,"bio":null,"public_repos":13,"public_gists":0,"followers":7,"following":0,"created_at":"2012-04-01T11:52:16Z","updated_at":"2017-11-20T21:53:27Z","private_gists":0,"total_private_repos":1,"owned_private_repos":0,"disk_usage":32253,"collaborators":0,"two_factor_authentication":true,"plan":{"name":"free","space":976562499,"collaborators":0,"private_repos":0}}'
+        Duck","company":"@momcorp","blog":"","location":"Berlin","email":"donald.pub2@gmail.com","hireable":true,"bio":null,"public_repos":19,"public_gists":0,"followers":9,"following":0,"created_at":"2012-04-01T11:52:16Z","updated_at":"2018-01-30T20:56:34Z","private_gists":0,"total_private_repos":0,"owned_private_repos":0,"disk_usage":32597,"collaborators":0,"two_factor_authentication":true,"plan":{"name":"free","space":976562499,"collaborators":0,"private_repos":0}}'
     http_version: 
-  recorded_at: Tue, 21 Nov 2017 09:42:49 GMT
+  recorded_at: Mon, 05 Feb 2018 21:10:35 GMT
+- request:
+    method: get
+    uri: https://api.github.com/user
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Ruby
+      Host:
+      - api.github.com
+      Authorization:
+      - Basic <GITHUB_CREDENTIALS>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Mon, 05 Feb 2018 21:10:36 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4972'
+      X-Ratelimit-Reset:
+      - '1517867477'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      Etag:
+      - W/"867a7455cae6fa03110405ae3f4f8ffe"
+      Last-Modified:
+      - Tue, 30 Jan 2018 20:56:34 GMT
+      X-Oauth-Scopes:
+      - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
+        delete_repo, gist, notifications, repo, user
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - default-src 'none'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Runtime-Rack:
+      - '0.045702'
+      X-Github-Request-Id:
+      - AF5E:14EE:371ED64:852C133:5A78C84C
+    body:
+      encoding: ASCII-8BIT
+      string: '{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false,"name":"Donald
+        Duck","company":"@momcorp","blog":"","location":"Berlin","email":"donald.pub2@gmail.com","hireable":true,"bio":null,"public_repos":19,"public_gists":0,"followers":9,"following":0,"created_at":"2012-04-01T11:52:16Z","updated_at":"2018-01-30T20:56:34Z","private_gists":0,"total_private_repos":0,"owned_private_repos":0,"disk_usage":32597,"collaborators":0,"two_factor_authentication":true,"plan":{"name":"free","space":976562499,"collaborators":0,"private_repos":0}}'
+    http_version: 
+  recorded_at: Mon, 05 Feb 2018 21:10:36 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/donald-fr/testrepo_u/collaborators/donaldduck/permission
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Ruby
+      Host:
+      - api.github.com
+      Authorization:
+      - Basic <GITHUB_CREDENTIALS>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Mon, 05 Feb 2018 21:10:37 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4971'
+      X-Ratelimit-Reset:
+      - '1517867477'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      Etag:
+      - W/"e4fff88fc0fa32cbe968faae12f06df9"
+      X-Oauth-Scopes:
+      - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
+        delete_repo, gist, notifications, repo, user
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - default-src 'none'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Runtime-Rack:
+      - '0.066955'
+      X-Github-Request-Id:
+      - AF60:14EE:371EDB2:852C1E4:5A78C84D
+    body:
+      encoding: ASCII-8BIT
+      string: '{"permission":"write","user":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false}}'
+    http_version: 
+  recorded_at: Mon, 05 Feb 2018 21:10:37 GMT
+- request:
+    method: get
+    uri: https://api.github.com/user
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Ruby
+      Host:
+      - api.github.com
+      Authorization:
+      - Basic <GITHUB_CREDENTIALS>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Mon, 05 Feb 2018 21:10:38 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4970'
+      X-Ratelimit-Reset:
+      - '1517867477'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      Etag:
+      - W/"867a7455cae6fa03110405ae3f4f8ffe"
+      Last-Modified:
+      - Tue, 30 Jan 2018 20:56:34 GMT
+      X-Oauth-Scopes:
+      - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
+        delete_repo, gist, notifications, repo, user
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - default-src 'none'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Runtime-Rack:
+      - '0.043691'
+      X-Github-Request-Id:
+      - E522:14ED:3F83C6B:8003A48:5A78C84E
+    body:
+      encoding: ASCII-8BIT
+      string: '{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false,"name":"Donald
+        Duck","company":"@momcorp","blog":"","location":"Berlin","email":"donald.pub2@gmail.com","hireable":true,"bio":null,"public_repos":19,"public_gists":0,"followers":9,"following":0,"created_at":"2012-04-01T11:52:16Z","updated_at":"2018-01-30T20:56:34Z","private_gists":0,"total_private_repos":0,"owned_private_repos":0,"disk_usage":32597,"collaborators":0,"two_factor_authentication":true,"plan":{"name":"free","space":976562499,"collaborators":0,"private_repos":0}}'
+    http_version: 
+  recorded_at: Mon, 05 Feb 2018 21:10:38 GMT
 - request:
     method: post
-    uri: https://api.github.com/repos/donald-fr/testrepo_u/issues/4/assignees
+    uri: https://api.github.com/repos/donald-fr/testrepo_u/pulls
+    body:
+      encoding: UTF-8
+      string: '{"title":"Title","body":"Description","head":"donaldduck:mybranch","base":"master"}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Ruby
+      Host:
+      - api.github.com
+      Authorization:
+      - Basic <GITHUB_CREDENTIALS>
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Mon, 05 Feb 2018 21:10:40 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '14982'
+      Status:
+      - 201 Created
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4969'
+      X-Ratelimit-Reset:
+      - '1517867477'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      Etag:
+      - '"16eee01131c02de43ebb3382d7a1a4eb"'
+      X-Oauth-Scopes:
+      - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
+        delete_repo, gist, notifications, repo, user
+      X-Accepted-Oauth-Scopes:
+      - ''
+      Location:
+      - https://api.github.com/repos/donald-fr/testrepo_u/pulls/8
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - default-src 'none'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Runtime-Rack:
+      - '0.535674'
+      X-Github-Request-Id:
+      - E524:14ED:3F83CCE:8003B2D:5A78C84F
+    body:
+      encoding: UTF-8
+      string: '{"url":"https://api.github.com/repos/donald-fr/testrepo_u/pulls/8","id":123456388,"html_url":"https://github.com/donald-fr/testrepo_u/pull/8","diff_url":"https://github.com/donald-fr/testrepo_u/pull/8.diff","patch_url":"https://github.com/donald-fr/testrepo_u/pull/8.patch","issue_url":"https://api.github.com/repos/donald-fr/testrepo_u/issues/8","number":8,"state":"open","locked":false,"title":"Title","user":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"body":"Description","created_at":"2018-02-05T21:10:39Z","updated_at":"2018-02-05T21:10:39Z","closed_at":null,"merged_at":null,"merge_commit_sha":null,"assignee":null,"assignees":[],"requested_reviewers":[],"requested_teams":[],"milestone":null,"commits_url":"https://api.github.com/repos/donald-fr/testrepo_u/pulls/8/commits","review_comments_url":"https://api.github.com/repos/donald-fr/testrepo_u/pulls/8/comments","review_comment_url":"https://api.github.com/repos/donald-fr/testrepo_u/pulls/comments{/number}","comments_url":"https://api.github.com/repos/donald-fr/testrepo_u/issues/8/comments","statuses_url":"https://api.github.com/repos/donald-fr/testrepo_u/statuses/2ed302a6c2b3bbfab51c64321b20b854017b97ee","head":{"label":"donaldduck:mybranch","ref":"mybranch","sha":"2ed302a6c2b3bbfab51c64321b20b854017b97ee","user":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"repo":{"id":123456502,"name":"testrepo_f","full_name":"donaldduck/testrepo_f","owner":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"private":false,"html_url":"https://github.com/donaldduck/testrepo_f","description":null,"fork":true,"url":"https://api.github.com/repos/donaldduck/testrepo_f","forks_url":"https://api.github.com/repos/donaldduck/testrepo_f/forks","keys_url":"https://api.github.com/repos/donaldduck/testrepo_f/keys{/key_id}","collaborators_url":"https://api.github.com/repos/donaldduck/testrepo_f/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/donaldduck/testrepo_f/teams","hooks_url":"https://api.github.com/repos/donaldduck/testrepo_f/hooks","issue_events_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/events{/number}","events_url":"https://api.github.com/repos/donaldduck/testrepo_f/events","assignees_url":"https://api.github.com/repos/donaldduck/testrepo_f/assignees{/user}","branches_url":"https://api.github.com/repos/donaldduck/testrepo_f/branches{/branch}","tags_url":"https://api.github.com/repos/donaldduck/testrepo_f/tags","blobs_url":"https://api.github.com/repos/donaldduck/testrepo_f/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/donaldduck/testrepo_f/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/donaldduck/testrepo_f/git/refs{/sha}","trees_url":"https://api.github.com/repos/donaldduck/testrepo_f/git/trees{/sha}","statuses_url":"https://api.github.com/repos/donaldduck/testrepo_f/statuses/{sha}","languages_url":"https://api.github.com/repos/donaldduck/testrepo_f/languages","stargazers_url":"https://api.github.com/repos/donaldduck/testrepo_f/stargazers","contributors_url":"https://api.github.com/repos/donaldduck/testrepo_f/contributors","subscribers_url":"https://api.github.com/repos/donaldduck/testrepo_f/subscribers","subscription_url":"https://api.github.com/repos/donaldduck/testrepo_f/subscription","commits_url":"https://api.github.com/repos/donaldduck/testrepo_f/commits{/sha}","git_commits_url":"https://api.github.com/repos/donaldduck/testrepo_f/git/commits{/sha}","comments_url":"https://api.github.com/repos/donaldduck/testrepo_f/comments{/number}","issue_comment_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/comments{/number}","contents_url":"https://api.github.com/repos/donaldduck/testrepo_f/contents/{+path}","compare_url":"https://api.github.com/repos/donaldduck/testrepo_f/compare/{base}...{head}","merges_url":"https://api.github.com/repos/donaldduck/testrepo_f/merges","archive_url":"https://api.github.com/repos/donaldduck/testrepo_f/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/donaldduck/testrepo_f/downloads","issues_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues{/number}","pulls_url":"https://api.github.com/repos/donaldduck/testrepo_f/pulls{/number}","milestones_url":"https://api.github.com/repos/donaldduck/testrepo_f/milestones{/number}","notifications_url":"https://api.github.com/repos/donaldduck/testrepo_f/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/donaldduck/testrepo_f/labels{/name}","releases_url":"https://api.github.com/repos/donaldduck/testrepo_f/releases{/id}","deployments_url":"https://api.github.com/repos/donaldduck/testrepo_f/deployments","created_at":"2018-02-05T20:44:53Z","updated_at":"2018-02-05T21:04:59Z","pushed_at":"2018-02-05T21:07:31Z","git_url":"git://github.com/donaldduck/testrepo_f.git","ssh_url":"git@github.com:donaldduck/testrepo_f.git","clone_url":"https://github.com/donaldduck/testrepo_f.git","svn_url":"https://github.com/donaldduck/testrepo_f","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":false,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"open_issues_count":1,"license":null,"forks":0,"open_issues":1,"watchers":0,"default_branch":"master"}},"base":{"label":"donald-fr:master","ref":"master","sha":"c971bf0ec8076e78b866a41ba4c3a83bc6a4be73","user":{"login":"donald-fr","id":12345612,"avatar_url":"https://avatars2.githubusercontent.com/u/33847412?v=4","gravatar_id":"","url":"https://api.github.com/users/donald-fr","html_url":"https://github.com/donald-fr","followers_url":"https://api.github.com/users/donald-fr/followers","following_url":"https://api.github.com/users/donald-fr/following{/other_user}","gists_url":"https://api.github.com/users/donald-fr/gists{/gist_id}","starred_url":"https://api.github.com/users/donald-fr/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donald-fr/subscriptions","organizations_url":"https://api.github.com/users/donald-fr/orgs","repos_url":"https://api.github.com/users/donald-fr/repos","events_url":"https://api.github.com/users/donald-fr/events{/privacy}","received_events_url":"https://api.github.com/users/donald-fr/received_events","type":"User","site_admin":false},"repo":{"id":123456004,"name":"testrepo_u","full_name":"donald-fr/testrepo_u","owner":{"login":"donald-fr","id":12345612,"avatar_url":"https://avatars2.githubusercontent.com/u/33847412?v=4","gravatar_id":"","url":"https://api.github.com/users/donald-fr","html_url":"https://github.com/donald-fr","followers_url":"https://api.github.com/users/donald-fr/followers","following_url":"https://api.github.com/users/donald-fr/following{/other_user}","gists_url":"https://api.github.com/users/donald-fr/gists{/gist_id}","starred_url":"https://api.github.com/users/donald-fr/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donald-fr/subscriptions","organizations_url":"https://api.github.com/users/donald-fr/orgs","repos_url":"https://api.github.com/users/donald-fr/repos","events_url":"https://api.github.com/users/donald-fr/events{/privacy}","received_events_url":"https://api.github.com/users/donald-fr/received_events","type":"User","site_admin":false},"private":false,"html_url":"https://github.com/donald-fr/testrepo_u","description":null,"fork":false,"url":"https://api.github.com/repos/donald-fr/testrepo_u","forks_url":"https://api.github.com/repos/donald-fr/testrepo_u/forks","keys_url":"https://api.github.com/repos/donald-fr/testrepo_u/keys{/key_id}","collaborators_url":"https://api.github.com/repos/donald-fr/testrepo_u/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/donald-fr/testrepo_u/teams","hooks_url":"https://api.github.com/repos/donald-fr/testrepo_u/hooks","issue_events_url":"https://api.github.com/repos/donald-fr/testrepo_u/issues/events{/number}","events_url":"https://api.github.com/repos/donald-fr/testrepo_u/events","assignees_url":"https://api.github.com/repos/donald-fr/testrepo_u/assignees{/user}","branches_url":"https://api.github.com/repos/donald-fr/testrepo_u/branches{/branch}","tags_url":"https://api.github.com/repos/donald-fr/testrepo_u/tags","blobs_url":"https://api.github.com/repos/donald-fr/testrepo_u/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/donald-fr/testrepo_u/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/donald-fr/testrepo_u/git/refs{/sha}","trees_url":"https://api.github.com/repos/donald-fr/testrepo_u/git/trees{/sha}","statuses_url":"https://api.github.com/repos/donald-fr/testrepo_u/statuses/{sha}","languages_url":"https://api.github.com/repos/donald-fr/testrepo_u/languages","stargazers_url":"https://api.github.com/repos/donald-fr/testrepo_u/stargazers","contributors_url":"https://api.github.com/repos/donald-fr/testrepo_u/contributors","subscribers_url":"https://api.github.com/repos/donald-fr/testrepo_u/subscribers","subscription_url":"https://api.github.com/repos/donald-fr/testrepo_u/subscription","commits_url":"https://api.github.com/repos/donald-fr/testrepo_u/commits{/sha}","git_commits_url":"https://api.github.com/repos/donald-fr/testrepo_u/git/commits{/sha}","comments_url":"https://api.github.com/repos/donald-fr/testrepo_u/comments{/number}","issue_comment_url":"https://api.github.com/repos/donald-fr/testrepo_u/issues/comments{/number}","contents_url":"https://api.github.com/repos/donald-fr/testrepo_u/contents/{+path}","compare_url":"https://api.github.com/repos/donald-fr/testrepo_u/compare/{base}...{head}","merges_url":"https://api.github.com/repos/donald-fr/testrepo_u/merges","archive_url":"https://api.github.com/repos/donald-fr/testrepo_u/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/donald-fr/testrepo_u/downloads","issues_url":"https://api.github.com/repos/donald-fr/testrepo_u/issues{/number}","pulls_url":"https://api.github.com/repos/donald-fr/testrepo_u/pulls{/number}","milestones_url":"https://api.github.com/repos/donald-fr/testrepo_u/milestones{/number}","notifications_url":"https://api.github.com/repos/donald-fr/testrepo_u/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/donald-fr/testrepo_u/labels{/name}","releases_url":"https://api.github.com/repos/donald-fr/testrepo_u/releases{/id}","deployments_url":"https://api.github.com/repos/donald-fr/testrepo_u/deployments","created_at":"2017-11-21T09:16:55Z","updated_at":"2017-11-21T11:59:32Z","pushed_at":"2018-02-01T15:22:37Z","git_url":"git://github.com/donald-fr/testrepo_u.git","ssh_url":"git@github.com:donald-fr/testrepo_u.git","clone_url":"https://github.com/donald-fr/testrepo_u.git","svn_url":"https://github.com/donald-fr/testrepo_u","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":false,"has_downloads":true,"has_wiki":false,"has_pages":false,"forks_count":1,"mirror_url":null,"archived":false,"open_issues_count":3,"license":null,"forks":1,"open_issues":3,"watchers":0,"default_branch":"master"}},"_links":{"self":{"href":"https://api.github.com/repos/donald-fr/testrepo_u/pulls/8"},"html":{"href":"https://github.com/donald-fr/testrepo_u/pull/8"},"issue":{"href":"https://api.github.com/repos/donald-fr/testrepo_u/issues/8"},"comments":{"href":"https://api.github.com/repos/donald-fr/testrepo_u/issues/8/comments"},"review_comments":{"href":"https://api.github.com/repos/donald-fr/testrepo_u/pulls/8/comments"},"review_comment":{"href":"https://api.github.com/repos/donald-fr/testrepo_u/pulls/comments{/number}"},"commits":{"href":"https://api.github.com/repos/donald-fr/testrepo_u/pulls/8/commits"},"statuses":{"href":"https://api.github.com/repos/donald-fr/testrepo_u/statuses/2ed302a6c2b3bbfab51c64321b20b854017b97ee"}},"author_association":"COLLABORATOR","merged":false,"mergeable":null,"rebaseable":null,"mergeable_state":"unknown","merged_by":null,"comments":0,"review_comments":0,"maintainer_can_modify":true,"commits":1,"additions":0,"deletions":0,"changed_files":1}'
+    http_version: 
+  recorded_at: Mon, 05 Feb 2018 21:10:40 GMT
+- request:
+    method: get
+    uri: https://api.github.com/user
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Ruby
+      Host:
+      - api.github.com
+      Authorization:
+      - Basic <GITHUB_CREDENTIALS>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Mon, 05 Feb 2018 21:10:41 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4968'
+      X-Ratelimit-Reset:
+      - '1517867477'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      Etag:
+      - W/"867a7455cae6fa03110405ae3f4f8ffe"
+      Last-Modified:
+      - Tue, 30 Jan 2018 20:56:34 GMT
+      X-Oauth-Scopes:
+      - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
+        delete_repo, gist, notifications, repo, user
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - default-src 'none'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Runtime-Rack:
+      - '0.067671'
+      X-Github-Request-Id:
+      - AF6A:14EC:2F987CE:65E57FE:5A78C850
+    body:
+      encoding: ASCII-8BIT
+      string: '{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false,"name":"Donald
+        Duck","company":"@momcorp","blog":"","location":"Berlin","email":"donald.pub2@gmail.com","hireable":true,"bio":null,"public_repos":19,"public_gists":0,"followers":9,"following":0,"created_at":"2012-04-01T11:52:16Z","updated_at":"2018-01-30T20:56:34Z","private_gists":0,"total_private_repos":0,"owned_private_repos":0,"disk_usage":32597,"collaborators":0,"two_factor_authentication":true,"plan":{"name":"free","space":976562499,"collaborators":0,"private_repos":0}}'
+    http_version: 
+  recorded_at: Mon, 05 Feb 2018 21:10:41 GMT
+- request:
+    method: post
+    uri: https://api.github.com/repos/donald-fr/testrepo_u/issues/8/assignees
     body:
       encoding: UTF-8
       string: '{"assignees":["donaldduck"]}'
@@ -258,32 +634,32 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Tue, 21 Nov 2017 09:42:50 GMT
+      - Mon, 05 Feb 2018 21:10:42 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '3865'
+      - '3866'
       Status:
       - 201 Created
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4987'
+      - '4967'
       X-Ratelimit-Reset:
-      - '1511259603'
+      - '1517867477'
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Vary:
       - Accept, Authorization, Cookie, X-GitHub-OTP
       Etag:
-      - '"ef0ede4eeda1cfa1e1d49acbcca9ce35"'
+      - '"86809aa157aa280508bdaeccdca93dd4"'
       X-Oauth-Scopes:
       - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
         delete_repo, gist, notifications, repo, user
       X-Accepted-Oauth-Scopes:
       - ''
       Location:
-      - https://api.github.com/repos/donald-fr/testrepo_u/issues/4
+      - https://api.github.com/repos/donald-fr/testrepo_u/issues/8
       X-Github-Media-Type:
       - github.v3; format=json
       Access-Control-Expose-Headers:
@@ -302,12 +678,12 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Runtime-Rack:
-      - '0.145315'
+      - '0.153192'
       X-Github-Request-Id:
-      - AA4C:62B1:2740DD:514C62:5A13F519
+      - E52A:14EE:371EF91:852C61D:5A78C851
     body:
       encoding: UTF-8
-      string: '{"url":"https://api.github.com/repos/donald-fr/testrepo_u/issues/4","repository_url":"https://api.github.com/repos/donald-fr/testrepo_u","labels_url":"https://api.github.com/repos/donald-fr/testrepo_u/issues/4/labels{/name}","comments_url":"https://api.github.com/repos/donald-fr/testrepo_u/issues/4/comments","events_url":"https://api.github.com/repos/donald-fr/testrepo_u/issues/4/events","html_url":"https://github.com/donald-fr/testrepo_u/pull/4","id":123456704,"number":4,"title":"Title","user":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"labels":[],"state":"open","locked":false,"assignee":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"assignees":[{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false}],"milestone":null,"comments":0,"created_at":"2017-11-21T09:42:48Z","updated_at":"2017-11-21T09:42:50Z","closed_at":null,"author_association":"CONTRIBUTOR","pull_request":{"url":"https://api.github.com/repos/donald-fr/testrepo_u/pulls/4","html_url":"https://github.com/donald-fr/testrepo_u/pull/4","diff_url":"https://github.com/donald-fr/testrepo_u/pull/4.diff","patch_url":"https://github.com/donald-fr/testrepo_u/pull/4.patch"},"body":"Description"}'
+      string: '{"url":"https://api.github.com/repos/donald-fr/testrepo_u/issues/8","repository_url":"https://api.github.com/repos/donald-fr/testrepo_u","labels_url":"https://api.github.com/repos/donald-fr/testrepo_u/issues/8/labels{/name}","comments_url":"https://api.github.com/repos/donald-fr/testrepo_u/issues/8/comments","events_url":"https://api.github.com/repos/donald-fr/testrepo_u/issues/8/events","html_url":"https://github.com/donald-fr/testrepo_u/pull/8","id":123456306,"number":8,"title":"Title","user":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"labels":[],"state":"open","locked":false,"assignee":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"assignees":[{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false}],"milestone":null,"comments":0,"created_at":"2018-02-05T21:10:39Z","updated_at":"2018-02-05T21:10:42Z","closed_at":null,"author_association":"COLLABORATOR","pull_request":{"url":"https://api.github.com/repos/donald-fr/testrepo_u/pulls/8","html_url":"https://github.com/donald-fr/testrepo_u/pull/8","diff_url":"https://github.com/donald-fr/testrepo_u/pull/8.diff","patch_url":"https://github.com/donald-fr/testrepo_u/pull/8.patch"},"body":"Description"}'
     http_version: 
-  recorded_at: Tue, 21 Nov 2017 09:42:50 GMT
+  recorded_at: Mon, 05 Feb 2018 21:10:42 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/create_pr_upstream_without_write_permissions.yml
+++ b/spec/vcr_cassettes/create_pr_upstream_without_write_permissions.yml
@@ -1,0 +1,305 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.github.com/user
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Ruby
+      Host:
+      - api.github.com
+      Authorization:
+      - Basic <GITHUB_CREDENTIALS>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Mon, 05 Feb 2018 21:58:37 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4997'
+      X-Ratelimit-Reset:
+      - '1517871079'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      Etag:
+      - W/"867a7455cae6fa03110405ae3f4f8ffe"
+      Last-Modified:
+      - Tue, 30 Jan 2018 20:56:34 GMT
+      X-Oauth-Scopes:
+      - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
+        delete_repo, gist, notifications, repo, user
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - default-src 'none'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Runtime-Rack:
+      - '0.055159'
+      X-Github-Request-Id:
+      - B27C:14EC:2FD8ADD:666FCAC:5A78D38D
+    body:
+      encoding: ASCII-8BIT
+      string: '{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false,"name":"Donald
+        Duck","company":"@momcorp","blog":"","location":"Berlin","email":"donald.pub2@gmail.com","hireable":true,"bio":null,"public_repos":19,"public_gists":0,"followers":9,"following":0,"created_at":"2012-04-01T11:52:16Z","updated_at":"2018-01-30T20:56:34Z","private_gists":0,"total_private_repos":0,"owned_private_repos":0,"disk_usage":32597,"collaborators":0,"two_factor_authentication":true,"plan":{"name":"free","space":976562499,"collaborators":0,"private_repos":0}}'
+    http_version: 
+  recorded_at: Mon, 05 Feb 2018 21:58:37 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/donald-fr/testrepo_u/collaborators/donaldduck
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Ruby
+      Host:
+      - api.github.com
+      Authorization:
+      - Basic <GITHUB_CREDENTIALS>
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Mon, 05 Feb 2018 21:58:38 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 403 Forbidden
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4996'
+      X-Ratelimit-Reset:
+      - '1517871079'
+      X-Oauth-Scopes:
+      - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
+        delete_repo, gist, notifications, repo, user
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - default-src 'none'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Runtime-Rack:
+      - '0.034945'
+      X-Github-Request-Id:
+      - E83C:14EC:2FD8B22:666FD26:5A78D38E
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"Must have push access to view repository collaborators.","documentation_url":"https://developer.github.com/v3/repos/collaborators/#check-if-a-user-is-a-collaborator"}'
+    http_version: 
+  recorded_at: Mon, 05 Feb 2018 21:58:38 GMT
+- request:
+    method: get
+    uri: https://api.github.com/user
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Ruby
+      Host:
+      - api.github.com
+      Authorization:
+      - Basic <GITHUB_CREDENTIALS>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Mon, 05 Feb 2018 21:58:39 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4995'
+      X-Ratelimit-Reset:
+      - '1517871079'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      Etag:
+      - W/"867a7455cae6fa03110405ae3f4f8ffe"
+      Last-Modified:
+      - Tue, 30 Jan 2018 20:56:34 GMT
+      X-Oauth-Scopes:
+      - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
+        delete_repo, gist, notifications, repo, user
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - default-src 'none'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Runtime-Rack:
+      - '0.045286'
+      X-Github-Request-Id:
+      - E83E:14EE:376B7E1:85DAA3A:5A78D38E
+    body:
+      encoding: ASCII-8BIT
+      string: '{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false,"name":"Donald
+        Duck","company":"@momcorp","blog":"","location":"Berlin","email":"donald.pub2@gmail.com","hireable":true,"bio":null,"public_repos":19,"public_gists":0,"followers":9,"following":0,"created_at":"2012-04-01T11:52:16Z","updated_at":"2018-01-30T20:56:34Z","private_gists":0,"total_private_repos":0,"owned_private_repos":0,"disk_usage":32597,"collaborators":0,"two_factor_authentication":true,"plan":{"name":"free","space":976562499,"collaborators":0,"private_repos":0}}'
+    http_version: 
+  recorded_at: Mon, 05 Feb 2018 21:58:39 GMT
+- request:
+    method: post
+    uri: https://api.github.com/repos/donald-fr/testrepo_u/pulls
+    body:
+      encoding: UTF-8
+      string: '{"title":"Title","body":"Description","head":"donaldduck:mybranch","base":"master"}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Ruby
+      Host:
+      - api.github.com
+      Authorization:
+      - Basic <GITHUB_CREDENTIALS>
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Mon, 05 Feb 2018 21:58:40 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '14982'
+      Status:
+      - 201 Created
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4994'
+      X-Ratelimit-Reset:
+      - '1517871079'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      Etag:
+      - '"fb172e851ffed3661b237056ea195e60"'
+      X-Oauth-Scopes:
+      - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
+        delete_repo, gist, notifications, repo, user
+      X-Accepted-Oauth-Scopes:
+      - ''
+      Location:
+      - https://api.github.com/repos/donald-fr/testrepo_u/pulls/9
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - default-src 'none'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Runtime-Rack:
+      - '0.538686'
+      X-Github-Request-Id:
+      - E840:14EE:376B822:85DAAF3:5A78D38F
+    body:
+      encoding: UTF-8
+      string: '{"url":"https://api.github.com/repos/donald-fr/testrepo_u/pulls/9","id":123456780,"html_url":"https://github.com/donald-fr/testrepo_u/pull/9","diff_url":"https://github.com/donald-fr/testrepo_u/pull/9.diff","patch_url":"https://github.com/donald-fr/testrepo_u/pull/9.patch","issue_url":"https://api.github.com/repos/donald-fr/testrepo_u/issues/9","number":9,"state":"open","locked":false,"title":"Title","user":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"body":"Description","created_at":"2018-02-05T21:58:39Z","updated_at":"2018-02-05T21:58:39Z","closed_at":null,"merged_at":null,"merge_commit_sha":null,"assignee":null,"assignees":[],"requested_reviewers":[],"requested_teams":[],"milestone":null,"commits_url":"https://api.github.com/repos/donald-fr/testrepo_u/pulls/9/commits","review_comments_url":"https://api.github.com/repos/donald-fr/testrepo_u/pulls/9/comments","review_comment_url":"https://api.github.com/repos/donald-fr/testrepo_u/pulls/comments{/number}","comments_url":"https://api.github.com/repos/donald-fr/testrepo_u/issues/9/comments","statuses_url":"https://api.github.com/repos/donald-fr/testrepo_u/statuses/cac905f20a0b8915b4cfb6cc7679672483ca84a8","head":{"label":"donaldduck:mybranch","ref":"mybranch","sha":"cac905f20a0b8915b4cfb6cc7679672483ca84a8","user":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"repo":{"id":123456635,"name":"testrepo_f","full_name":"donaldduck/testrepo_f","owner":{"login":"donaldduck","id":1234566,"avatar_url":"https://avatars2.githubusercontent.com/u/123456?v=4","gravatar_id":"","url":"https://api.github.com/users/donaldduck","html_url":"https://github.com/donaldduck","followers_url":"https://api.github.com/users/donaldduck/followers","following_url":"https://api.github.com/users/donaldduck/following{/other_user}","gists_url":"https://api.github.com/users/donaldduck/gists{/gist_id}","starred_url":"https://api.github.com/users/donaldduck/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donaldduck/subscriptions","organizations_url":"https://api.github.com/users/donaldduck/orgs","repos_url":"https://api.github.com/users/donaldduck/repos","events_url":"https://api.github.com/users/donaldduck/events{/privacy}","received_events_url":"https://api.github.com/users/donaldduck/received_events","type":"User","site_admin":false},"private":false,"html_url":"https://github.com/donaldduck/testrepo_f","description":null,"fork":true,"url":"https://api.github.com/repos/donaldduck/testrepo_f","forks_url":"https://api.github.com/repos/donaldduck/testrepo_f/forks","keys_url":"https://api.github.com/repos/donaldduck/testrepo_f/keys{/key_id}","collaborators_url":"https://api.github.com/repos/donaldduck/testrepo_f/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/donaldduck/testrepo_f/teams","hooks_url":"https://api.github.com/repos/donaldduck/testrepo_f/hooks","issue_events_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/events{/number}","events_url":"https://api.github.com/repos/donaldduck/testrepo_f/events","assignees_url":"https://api.github.com/repos/donaldduck/testrepo_f/assignees{/user}","branches_url":"https://api.github.com/repos/donaldduck/testrepo_f/branches{/branch}","tags_url":"https://api.github.com/repos/donaldduck/testrepo_f/tags","blobs_url":"https://api.github.com/repos/donaldduck/testrepo_f/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/donaldduck/testrepo_f/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/donaldduck/testrepo_f/git/refs{/sha}","trees_url":"https://api.github.com/repos/donaldduck/testrepo_f/git/trees{/sha}","statuses_url":"https://api.github.com/repos/donaldduck/testrepo_f/statuses/{sha}","languages_url":"https://api.github.com/repos/donaldduck/testrepo_f/languages","stargazers_url":"https://api.github.com/repos/donaldduck/testrepo_f/stargazers","contributors_url":"https://api.github.com/repos/donaldduck/testrepo_f/contributors","subscribers_url":"https://api.github.com/repos/donaldduck/testrepo_f/subscribers","subscription_url":"https://api.github.com/repos/donaldduck/testrepo_f/subscription","commits_url":"https://api.github.com/repos/donaldduck/testrepo_f/commits{/sha}","git_commits_url":"https://api.github.com/repos/donaldduck/testrepo_f/git/commits{/sha}","comments_url":"https://api.github.com/repos/donaldduck/testrepo_f/comments{/number}","issue_comment_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues/comments{/number}","contents_url":"https://api.github.com/repos/donaldduck/testrepo_f/contents/{+path}","compare_url":"https://api.github.com/repos/donaldduck/testrepo_f/compare/{base}...{head}","merges_url":"https://api.github.com/repos/donaldduck/testrepo_f/merges","archive_url":"https://api.github.com/repos/donaldduck/testrepo_f/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/donaldduck/testrepo_f/downloads","issues_url":"https://api.github.com/repos/donaldduck/testrepo_f/issues{/number}","pulls_url":"https://api.github.com/repos/donaldduck/testrepo_f/pulls{/number}","milestones_url":"https://api.github.com/repos/donaldduck/testrepo_f/milestones{/number}","notifications_url":"https://api.github.com/repos/donaldduck/testrepo_f/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/donaldduck/testrepo_f/labels{/name}","releases_url":"https://api.github.com/repos/donaldduck/testrepo_f/releases{/id}","deployments_url":"https://api.github.com/repos/donaldduck/testrepo_f/deployments","created_at":"2018-02-05T21:44:00Z","updated_at":"2018-02-05T21:44:40Z","pushed_at":"2018-02-05T21:45:22Z","git_url":"git://github.com/donaldduck/testrepo_f.git","ssh_url":"git@github.com:donaldduck/testrepo_f.git","clone_url":"https://github.com/donaldduck/testrepo_f.git","svn_url":"https://github.com/donaldduck/testrepo_f","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":false,"has_downloads":true,"has_wiki":false,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master"}},"base":{"label":"donald-fr:master","ref":"master","sha":"c971bf0ec8076e78b866a41ba4c3a83bc6a4be73","user":{"login":"donald-fr","id":12345612,"avatar_url":"https://avatars2.githubusercontent.com/u/33847412?v=4","gravatar_id":"","url":"https://api.github.com/users/donald-fr","html_url":"https://github.com/donald-fr","followers_url":"https://api.github.com/users/donald-fr/followers","following_url":"https://api.github.com/users/donald-fr/following{/other_user}","gists_url":"https://api.github.com/users/donald-fr/gists{/gist_id}","starred_url":"https://api.github.com/users/donald-fr/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donald-fr/subscriptions","organizations_url":"https://api.github.com/users/donald-fr/orgs","repos_url":"https://api.github.com/users/donald-fr/repos","events_url":"https://api.github.com/users/donald-fr/events{/privacy}","received_events_url":"https://api.github.com/users/donald-fr/received_events","type":"User","site_admin":false},"repo":{"id":123456004,"name":"testrepo_u","full_name":"donald-fr/testrepo_u","owner":{"login":"donald-fr","id":12345612,"avatar_url":"https://avatars2.githubusercontent.com/u/33847412?v=4","gravatar_id":"","url":"https://api.github.com/users/donald-fr","html_url":"https://github.com/donald-fr","followers_url":"https://api.github.com/users/donald-fr/followers","following_url":"https://api.github.com/users/donald-fr/following{/other_user}","gists_url":"https://api.github.com/users/donald-fr/gists{/gist_id}","starred_url":"https://api.github.com/users/donald-fr/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/donald-fr/subscriptions","organizations_url":"https://api.github.com/users/donald-fr/orgs","repos_url":"https://api.github.com/users/donald-fr/repos","events_url":"https://api.github.com/users/donald-fr/events{/privacy}","received_events_url":"https://api.github.com/users/donald-fr/received_events","type":"User","site_admin":false},"private":false,"html_url":"https://github.com/donald-fr/testrepo_u","description":null,"fork":false,"url":"https://api.github.com/repos/donald-fr/testrepo_u","forks_url":"https://api.github.com/repos/donald-fr/testrepo_u/forks","keys_url":"https://api.github.com/repos/donald-fr/testrepo_u/keys{/key_id}","collaborators_url":"https://api.github.com/repos/donald-fr/testrepo_u/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/donald-fr/testrepo_u/teams","hooks_url":"https://api.github.com/repos/donald-fr/testrepo_u/hooks","issue_events_url":"https://api.github.com/repos/donald-fr/testrepo_u/issues/events{/number}","events_url":"https://api.github.com/repos/donald-fr/testrepo_u/events","assignees_url":"https://api.github.com/repos/donald-fr/testrepo_u/assignees{/user}","branches_url":"https://api.github.com/repos/donald-fr/testrepo_u/branches{/branch}","tags_url":"https://api.github.com/repos/donald-fr/testrepo_u/tags","blobs_url":"https://api.github.com/repos/donald-fr/testrepo_u/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/donald-fr/testrepo_u/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/donald-fr/testrepo_u/git/refs{/sha}","trees_url":"https://api.github.com/repos/donald-fr/testrepo_u/git/trees{/sha}","statuses_url":"https://api.github.com/repos/donald-fr/testrepo_u/statuses/{sha}","languages_url":"https://api.github.com/repos/donald-fr/testrepo_u/languages","stargazers_url":"https://api.github.com/repos/donald-fr/testrepo_u/stargazers","contributors_url":"https://api.github.com/repos/donald-fr/testrepo_u/contributors","subscribers_url":"https://api.github.com/repos/donald-fr/testrepo_u/subscribers","subscription_url":"https://api.github.com/repos/donald-fr/testrepo_u/subscription","commits_url":"https://api.github.com/repos/donald-fr/testrepo_u/commits{/sha}","git_commits_url":"https://api.github.com/repos/donald-fr/testrepo_u/git/commits{/sha}","comments_url":"https://api.github.com/repos/donald-fr/testrepo_u/comments{/number}","issue_comment_url":"https://api.github.com/repos/donald-fr/testrepo_u/issues/comments{/number}","contents_url":"https://api.github.com/repos/donald-fr/testrepo_u/contents/{+path}","compare_url":"https://api.github.com/repos/donald-fr/testrepo_u/compare/{base}...{head}","merges_url":"https://api.github.com/repos/donald-fr/testrepo_u/merges","archive_url":"https://api.github.com/repos/donald-fr/testrepo_u/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/donald-fr/testrepo_u/downloads","issues_url":"https://api.github.com/repos/donald-fr/testrepo_u/issues{/number}","pulls_url":"https://api.github.com/repos/donald-fr/testrepo_u/pulls{/number}","milestones_url":"https://api.github.com/repos/donald-fr/testrepo_u/milestones{/number}","notifications_url":"https://api.github.com/repos/donald-fr/testrepo_u/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/donald-fr/testrepo_u/labels{/name}","releases_url":"https://api.github.com/repos/donald-fr/testrepo_u/releases{/id}","deployments_url":"https://api.github.com/repos/donald-fr/testrepo_u/deployments","created_at":"2017-11-21T09:16:55Z","updated_at":"2017-11-21T11:59:32Z","pushed_at":"2018-02-05T21:10:40Z","git_url":"git://github.com/donald-fr/testrepo_u.git","ssh_url":"git@github.com:donald-fr/testrepo_u.git","clone_url":"https://github.com/donald-fr/testrepo_u.git","svn_url":"https://github.com/donald-fr/testrepo_u","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":false,"has_downloads":true,"has_wiki":false,"has_pages":false,"forks_count":1,"mirror_url":null,"archived":false,"open_issues_count":3,"license":null,"forks":1,"open_issues":3,"watchers":0,"default_branch":"master"}},"_links":{"self":{"href":"https://api.github.com/repos/donald-fr/testrepo_u/pulls/9"},"html":{"href":"https://github.com/donald-fr/testrepo_u/pull/9"},"issue":{"href":"https://api.github.com/repos/donald-fr/testrepo_u/issues/9"},"comments":{"href":"https://api.github.com/repos/donald-fr/testrepo_u/issues/9/comments"},"review_comments":{"href":"https://api.github.com/repos/donald-fr/testrepo_u/pulls/9/comments"},"review_comment":{"href":"https://api.github.com/repos/donald-fr/testrepo_u/pulls/comments{/number}"},"commits":{"href":"https://api.github.com/repos/donald-fr/testrepo_u/pulls/9/commits"},"statuses":{"href":"https://api.github.com/repos/donald-fr/testrepo_u/statuses/cac905f20a0b8915b4cfb6cc7679672483ca84a8"}},"author_association":"CONTRIBUTOR","merged":false,"mergeable":null,"rebaseable":null,"mergeable_state":"unknown","merged_by":null,"comments":0,"review_comments":0,"maintainer_can_modify":true,"commits":1,"additions":0,"deletions":0,"changed_files":1}'
+    http_version: 
+  recorded_at: Mon, 05 Feb 2018 21:58:40 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
If the user doesn't have repo write permissions, PR attributes can't be set (and can't be read, either).

This PR also make a few improvements:

- Improve APIs usage in GitClient#gitdir_option (fixes a bug in GitClient#working_tree_clean?)
- Support 403 response on User#is_collaborator?

Closes #121.