### PR TITLE
Restore the dependency on tty-prompt, which now has the list filtering functionality

### DIFF
--- a/geet.gemspec
+++ b/geet.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.license     = 'GPL-3.0'
 
   s.add_runtime_dependency 'simple_scripting', '~> 0.9.4'
-  s.add_runtime_dependency 'temp-fork-tp-filter', '= 0.0.3'
+  s.add_runtime_dependency 'tty-prompt', '>= 0.15.0'
 
   s.add_development_dependency 'rake', '~> 12.3.0'
 

--- a/lib/geet/utils/manual_list_selection.rb
+++ b/lib/geet/utils/manual_list_selection.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'temp-fork-tp-filter'
+require 'tty-prompt'
 
 module Geet
   module Utils


### PR DESCRIPTION
The filtering functionality has been merged in on version 0.15.0.

Closes #108.