### PR TITLE
Add base branch option to PR creation

### DIFF
--- a/bin/geet
+++ b/bin/geet
@@ -49,7 +49,7 @@ class GeetLauncher
     when MILESTONE_LIST_COMMAND
       Services::ListMilestones.new(repository).execute
     when PR_CREATE_COMMAND
-      summary = options[:summary] || edit_pr_summary
+      summary = options[:summary] || edit_pr_summary(base: options[:base])
       title, description = split_summary(summary)
 
       options = default_to_manual_selection(options, :labels, :milestone, :reviewers)
@@ -66,11 +66,13 @@ class GeetLauncher
 
   private
 
-  def edit_pr_summary
+  def edit_pr_summary(base: nil)
+    base ||= 'master'
+
     # Tricky. It would be best to have Git logic exlusively inside the services,
     # but at the same time, the summary editing should be out.
     git = Utils::GitClient.new
-    pr_commits = git.cherry('master')
+    pr_commits = git.cherry(base)
 
     if pr_commits.size == 1
       prepopulated_summary = git.show_description('HEAD')

--- a/lib/geet/commandline/configuration.rb
+++ b/lib/geet/commandline/configuration.rb
@@ -52,6 +52,7 @@ module Geet
       PR_CREATE_OPTIONS = [
         ['-A', '--automated-mode',                          "Automate the branch operations (see long help)"],
         ['-n', '--no-open-pr',                              "Don't open the PR link in the browser after creation"],
+        ['-b', '--base develop',                            "Specify the base branch; defaults to `master`"],
         ['-l', '--labels "legacy,code review"',             'Labels'],
         ['-m', '--milestone 1.5.0',                         'Milestone title pattern'],
         ['-r', '--reviewers john,tom,adrian,kevin',         'Reviewer logins'],

--- a/lib/geet/git/repository.rb
+++ b/lib/geet/git/repository.rb
@@ -70,11 +70,11 @@ module Geet
         attempt_provider_call(:Milestone, :list, api_interface)
       end
 
-      def create_pr(title, description, head)
+      def create_pr(title, description, head, base: nil)
         confirm(LOCAL_ACTION_ON_UPSTREAM_REPOSITORY_MESSAGE) if local_action_on_upstream_repository? && @warnings
         confirm(ACTION_ON_PROTECTED_REPOSITORY_MESSAGE) if action_on_protected_repository? && @warnings
 
-        attempt_provider_call(:PR, :create, title, description, head, api_interface)
+        attempt_provider_call(:PR, :create, title, description, head, api_interface, base: base)
       end
 
       def prs(head: nil)

--- a/lib/geet/github/pr.rb
+++ b/lib/geet/github/pr.rb
@@ -8,15 +8,16 @@ module Geet
     class PR < AbstractIssue
       # See https://developer.github.com/v3/pulls/#create-a-pull-request
       #
-      def self.create(title, description, head, api_interface)
+      def self.create(title, description, head, api_interface, base: nil)
         api_path = 'pulls'
+        base ||= 'master'
 
         if api_interface.upstream?
           authenticated_user = Geet::Github::User.authenticated(api_interface).username
           head = "#{authenticated_user}:#{head}"
         end
 
-        request_data = { title: title, body: description, head: head, base: 'master' }
+        request_data = { title: title, body: description, head: head, base: base }
 
         response = api_interface.send_request(api_path, data: request_data)
 

--- a/lib/geet/services/create_pr.rb
+++ b/lib/geet/services/create_pr.rb
@@ -23,7 +23,7 @@ module Geet
       #
       def execute(
         title, description, labels: nil, milestone: nil, reviewers: nil,
-        no_open_pr: nil, automated_mode: false, **
+        base: nil, no_open_pr: nil, automated_mode: false, **
       )
         ensure_clean_tree if automated_mode
 
@@ -37,7 +37,7 @@ module Geet
 
         sync_with_upstream_branch if automated_mode
 
-        pr = create_pr(title, description)
+        pr = create_pr(title, description, base)
 
         if user_has_write_permissions
           edit_pr(pr, selected_labels, selected_milestone, selected_reviewers)
@@ -93,10 +93,10 @@ module Geet
         end
       end
 
-      def create_pr(title, description)
+      def create_pr(title, description, base)
         @out.puts 'Creating PR...'
 
-        @repository.create_pr(title, description, @git_client.current_branch)
+        @repository.create_pr(title, description, @git_client.current_branch, base: base)
       end
 
       def edit_pr(pr, labels, milestone, reviewers)


### PR DESCRIPTION
This is required for repositories not using the `master` branch convention.

Closes #128.