### PR TITLE
Fix OsHelper#execute_command on errors without stderr content

### DIFF
--- a/lib/geet/helpers/os_helper.rb
+++ b/lib/geet/helpers/os_helper.rb
@@ -44,7 +44,7 @@ module Geet
             puts stderr_content if stderr_content != '' && !silent_stderr
 
             if !wait_thread.value.success?
-              error_message = stderr_content.lines.first.strip
+              error_message = stderr_content.lines.first&.strip || "Error running command #{command.inspect}"
               raise "Error#{description_message}: #{error_message}"
             end
 


### PR DESCRIPTION
Commands exiting with an error but without stderr content (eg. `git rev-parse --abbrev-ref HEAD` outside a branch) previously were causing an error.

Such cases are now handled, using a generic error message.