### PR TITLE
Add Ruby 2.6 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
   - 2.3
   - 2.4
   - 2.5
+  - 2.6
 # API tokens are always required, but not used in testing, since no requests are actually made.
 env:
   - GITHUB_API_TOKEN=phony GITLAB_API_TOKEN=phony

--- a/geet.gemspec
+++ b/geet.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.description = 'Commandline interface for performing SCM host operations, eg. create a PR on GitHub, with support for multiple hosts.'
   s.license     = 'GPL-3.0'
 
-  s.add_runtime_dependency 'simple_scripting', '~> 0.10.1'
+  s.add_runtime_dependency 'simple_scripting', '~> 0.10.2'
   s.add_runtime_dependency 'tty-prompt', '~> 0.15.0'
 
   s.add_development_dependency 'rake', '~> 12.3'


### PR DESCRIPTION
Update the required dependency `simple_scripting`, and add Ruby 2.6 to the Travis build.