### PR TITLE
Upgrade simple_scripting dependency to v0.11

### DIFF
--- a/geet.gemspec
+++ b/geet.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.description = 'Commandline interface for performing SCM host operations, eg. create a PR on GitHub, with support for multiple hosts.'
   s.license     = 'GPL-3.0'
 
-  s.add_runtime_dependency 'simple_scripting', '~> 0.10.2'
+  s.add_runtime_dependency 'simple_scripting', '~> 0.11.0'
   s.add_runtime_dependency 'tty-prompt', '~> 0.15.0'
 
   s.add_development_dependency 'rake', '~> 12.3'


### PR DESCRIPTION
This version doesn't raise anymore errors by default, which was confusing; instead, it prints a message.