### PR TITLE
Add `--no-open-browser` option to PR comment

### DIFF
--- a/bin/geet
+++ b/bin/geet
@@ -51,7 +51,7 @@ class GeetLauncher
     when PR_COMMENT_COMMAND
       comment = options.delete(:comment)
 
-      Services::CommentPr.new(repository).execute(comment)
+      Services::CommentPr.new(repository).execute(comment, options)
     when PR_CREATE_COMMAND
       summary = options[:summary] || edit_pr_summary(base: options[:base])
       title, description = split_summary(summary)

--- a/lib/geet/commandline/configuration.rb
+++ b/lib/geet/commandline/configuration.rb
@@ -50,6 +50,7 @@ module Geet
       ].freeze
 
       PR_COMMENT_OPTIONS = [
+        ['-n', '--no-open-pr',                              "Don't open the PR link in the browser after creation"],
         'comment',
         long_help: 'Add a comment to the PR for the current branch.'
       ]

--- a/lib/geet/services/comment_pr.rb
+++ b/lib/geet/services/comment_pr.rb
@@ -19,11 +19,11 @@ module Geet
         @git_client = git_client
       end
 
-      def execute(comment)
+      def execute(comment, no_open_pr: nil)
         merge_owner, merge_head = find_merge_head
         pr = checked_find_branch_pr(merge_owner, merge_head)
         pr.comment(comment)
-        open_file_with_default_application(pr.link)
+        open_file_with_default_application(pr.link) unless no_open_pr
         pr
       end
     end


### PR DESCRIPTION
Based on the current use patterns, opening the browser is not useful.