### PR TITLE
Relax GitClient::UPSTREAM_BRANCH_REGEX

### DIFF
--- a/lib/geet/utils/git_client.rb
+++ b/lib/geet/utils/git_client.rb
@@ -34,7 +34,7 @@ module Geet
         \Z
       }x
 
-      UPSTREAM_BRANCH_REGEX = %r{\A[^/]+/([^/]+)\Z}
+      UPSTREAM_BRANCH_REGEX = %r{\A[^/]+/(.+)\Z}
 
       MAIN_BRANCH_CONFIG_ENTRY = 'custom.development-branch'
 


### PR DESCRIPTION
Now allows names like `origin/sav/mybranch`.