### PR TITLE
PR creation: Rename `upstream` branchs references/APIs to `remote`

### DIFF
--- a/lib/geet/services/create_pr.rb
+++ b/lib/geet/services/create_pr.rb
@@ -91,7 +91,7 @@ module Geet
 
           @out.puts "Creating upstream branch #{upstream_branch.inspect}..."
 
-          @git_client.push(upstream_branch: upstream_branch)
+          @git_client.push(remote_branch: upstream_branch)
         end
       end
 

--- a/lib/geet/services/create_pr.rb
+++ b/lib/geet/services/create_pr.rb
@@ -82,7 +82,7 @@ module Geet
       end
 
       def sync_with_upstream_branch
-        if @git_client.upstream_branch
+        if @git_client.remote_branch
           @out.puts "Pushing to upstream branch..."
 
           @git_client.push

--- a/lib/geet/services/create_pr.rb
+++ b/lib/geet/services/create_pr.rb
@@ -37,7 +37,7 @@ module Geet
           selected_labels, selected_milestone, selected_reviewers = find_and_select_attributes(labels, milestone, reviewers)
         end
 
-        sync_with_upstream_branch if automated_mode
+        sync_with_remote_branch if automated_mode
 
         pr = create_pr(title, description, base: base, draft: draft)
 
@@ -81,17 +81,17 @@ module Geet
         selection_manager.select_attributes
       end
 
-      def sync_with_upstream_branch
+      def sync_with_remote_branch
         if @git_client.remote_branch
-          @out.puts "Pushing to upstream branch..."
+          @out.puts "Pushing to remote branch..."
 
           @git_client.push
         else
-          upstream_branch = @git_client.current_branch
+          remote_branch = @git_client.current_branch
 
-          @out.puts "Creating upstream branch #{upstream_branch.inspect}..."
+          @out.puts "Creating remote branch #{remote_branch.inspect}..."
 
-          @git_client.push(remote_branch: upstream_branch)
+          @git_client.push(remote_branch: remote_branch)
         end
       end
 

--- a/lib/geet/services/merge_pr.rb
+++ b/lib/geet/services/merge_pr.rb
@@ -36,7 +36,7 @@ module Geet
 
         fetch_repository
 
-        if upstream_branch_gone?
+        if remote_branch_gone?
           pr_branch = @git_client.current_branch
           main_branch = @git_client.main_branch
 
@@ -72,8 +72,8 @@ module Geet
         @git_client.fetch
       end
 
-      def upstream_branch_gone?
-        @git_client.upstream_branch_gone?
+      def remote_branch_gone?
+        @git_client.remote_branch_gone?
       end
 
       def checkout_branch(branch)

--- a/lib/geet/utils/git_client.rb
+++ b/lib/geet/utils/git_client.rb
@@ -89,7 +89,7 @@ module Geet
       #     ## add_milestone_closing...origin/add_milestone_closing [gone]
       #      M spec/integration/merge_pr_spec.rb
       #
-      def upstream_branch_gone?
+      def remote_branch_gone?
         git_command = "status -b --porcelain"
         status_output = execute_git_command(git_command)
 

--- a/lib/geet/utils/git_client.rb
+++ b/lib/geet/utils/git_client.rb
@@ -216,10 +216,10 @@ module Geet
 
       # upstream_branch: create an upstream branch.
       #
-      def push(upstream_branch: nil)
-        upstream_branch_option = "-u #{ORIGIN_NAME} #{upstream_branch.shellescape}" if upstream_branch
+      def push(remote_branch: nil)
+        remote_branch_option = "-u #{ORIGIN_NAME} #{remote_branch.shellescape}" if remote_branch
 
-        execute_git_command("push #{upstream_branch_option}")
+        execute_git_command("push #{remote_branch_option}")
       end
 
       # Performs pruning.

--- a/lib/geet/utils/git_client.rb
+++ b/lib/geet/utils/git_client.rb
@@ -65,13 +65,11 @@ module Geet
         branch
       end
 
-      # Not to be confused with `upstream` repository!
-      #
       # This API doesn't reveal if the remote branch is gone.
       #
       # return: nil, if the upstream branch is not configured.
       #
-      def upstream_branch
+      def remote_branch
         head_symbolic_ref = execute_git_command("symbolic-ref -q HEAD")
 
         raw_upstream_branch = execute_git_command("for-each-ref --format='%(upstream:short)' #{head_symbolic_ref.shellescape}").strip
@@ -83,7 +81,7 @@ module Geet
         end
       end
 
-      # TODO: May be merged with :upstream_branch, although it would require designing how a gone
+      # TODO: May be merged with :remote_branch, although it would require designing how a gone
       # remote branch is expressed.
       #
       # Sample command output:

--- a/spec/integration/create_pr_spec.rb
+++ b/spec/integration/create_pr_spec.rb
@@ -164,7 +164,7 @@ describe Geet::Services::CreatePr do
         allow(git_client).to receive(:current_branch).and_return('mybranch')
         allow(git_client).to receive(:main_branch).and_return('master')
         expect(git_client).to receive(:remote_branch).and_return(nil)
-        expect(git_client).to receive(:push).with(upstream_branch: 'mybranch')
+        expect(git_client).to receive(:push).with(remote_branch: 'mybranch')
 
         allow(git_client).to receive(:remote).with(no_args).and_return('git@github.com:donaldduck/testrepo_f')
 

--- a/spec/integration/create_pr_spec.rb
+++ b/spec/integration/create_pr_spec.rb
@@ -137,7 +137,7 @@ describe Geet::Services::CreatePr do
         allow(git_client).to receive(:working_tree_clean?).and_return(true)
         allow(git_client).to receive(:current_branch).and_return('mybranch')
         allow(git_client).to receive(:main_branch).and_return('master')
-        expect(git_client).to receive(:upstream_branch).and_return('mybranch')
+        expect(git_client).to receive(:remote_branch).and_return('mybranch')
         expect(git_client).to receive(:push)
 
         allow(git_client).to receive(:remote).with(no_args).and_return('git@github.com:donaldduck/testrepo_f')
@@ -163,7 +163,7 @@ describe Geet::Services::CreatePr do
         allow(git_client).to receive(:working_tree_clean?).and_return(true)
         allow(git_client).to receive(:current_branch).and_return('mybranch')
         allow(git_client).to receive(:main_branch).and_return('master')
-        expect(git_client).to receive(:upstream_branch).and_return(nil)
+        expect(git_client).to receive(:remote_branch).and_return(nil)
         expect(git_client).to receive(:push).with(upstream_branch: 'mybranch')
 
         allow(git_client).to receive(:remote).with(no_args).and_return('git@github.com:donaldduck/testrepo_f')

--- a/spec/integration/create_pr_spec.rb
+++ b/spec/integration/create_pr_spec.rb
@@ -133,7 +133,7 @@ describe Geet::Services::CreatePr do
         expect(actual_output.string).to eql(expected_output)
       end
 
-      it 'should push to the upstream branch' do
+      it 'should push to the remote branch' do
         allow(git_client).to receive(:working_tree_clean?).and_return(true)
         allow(git_client).to receive(:current_branch).and_return('mybranch')
         allow(git_client).to receive(:main_branch).and_return('master')
@@ -143,7 +143,7 @@ describe Geet::Services::CreatePr do
         allow(git_client).to receive(:remote).with(no_args).and_return('git@github.com:donaldduck/testrepo_f')
 
         expected_output = <<~STR
-          Pushing to upstream branch...
+          Pushing to remote branch...
           Creating PR...
           Assigning authenticated user...
           PR address: https://github.com/donaldduck/testrepo_f/pull/2
@@ -159,7 +159,7 @@ describe Geet::Services::CreatePr do
         expect(actual_output.string).to eql(expected_output)
       end
 
-      it "should create an upstream branch, when there isn't one (is not tracked)" do
+      it "should create a remote branch, when there isn't one (is not tracked)" do
         allow(git_client).to receive(:working_tree_clean?).and_return(true)
         allow(git_client).to receive(:current_branch).and_return('mybranch')
         allow(git_client).to receive(:main_branch).and_return('master')
@@ -169,7 +169,7 @@ describe Geet::Services::CreatePr do
         allow(git_client).to receive(:remote).with(no_args).and_return('git@github.com:donaldduck/testrepo_f')
 
         expected_output = <<~STR
-          Creating upstream branch "mybranch"...
+          Creating remote branch "mybranch"...
           Creating PR...
           Assigning authenticated user...
           PR address: https://github.com/donaldduck/testrepo_f/pull/4

--- a/spec/integration/merge_pr_spec.rb
+++ b/spec/integration/merge_pr_spec.rb
@@ -7,7 +7,7 @@ require_relative '../../lib/geet/services/merge_pr'
 
 # Currently disabled: it requires updates following the addition of the automatic removal of the local
 # branch.
-# Specifically, `GitClient#upstream_branch_gone?` needs to be handled, since it returns the current
+# Specifically, `GitClient#remote_branch_gone?` needs to be handled, since it returns the current
 # branch, while it's supposed to return
 #
 describe Geet::Services::MergePr do
@@ -19,7 +19,7 @@ describe Geet::Services::MergePr do
 
   before :each do
     expect(git_client).to receive(:fetch)
-    expect(git_client).to receive(:upstream_branch_gone?).and_return(true)
+    expect(git_client).to receive(:remote_branch_gone?).and_return(true)
     expect(git_client).to receive(:checkout).with(main_branch)
     expect(git_client).to receive(:rebase)
     expect(git_client).to receive(:delete_branch).with('mybranch')


### PR DESCRIPTION
"Upstream" is not precise terminology, and it's confusing.